### PR TITLE
[#120] Update empty memo logic and UI for memo

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -55,7 +55,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        Memo memo = ParserUtil.parseMemo(argMultimap.getValueOrEmpty(PREFIX_MEMO));
+
+        Memo memo = Memo.EMPTY_MEMO;
+        if (argMultimap.getValue(PREFIX_MEMO).isPresent()) {
+            memo = ParserUtil.parseMemo(argMultimap.getValue(PREFIX_MEMO).get());
+        }
 
         Person person = new Person(name, phone, email, address, memo, tagList);
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -42,14 +42,6 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Returns the last value of {@code prefix} if value is not null; otherwise returns "".
-     */
-    public String getValueOrEmpty(Prefix prefix) {
-        List<String> values = getAllValues(prefix);
-        return values.isEmpty() ? "" : values.get(values.size() - 1);
-    }
-
-    /**
      * Returns all values of {@code prefix}.
      * If the prefix does not exist or has no values, this will return an empty list.
      * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -108,6 +108,9 @@ public class ParserUtil {
         if (!Memo.isValidMemo(trimmedMemo)) {
             throw new ParseException(Memo.MESSAGE_CONSTRAINTS);
         }
+        if (trimmedMemo.isEmpty()) {
+            return Memo.EMPTY_MEMO;
+        }
         return new Memo(trimmedMemo);
     }
 

--- a/src/main/java/seedu/address/model/person/Memo.java
+++ b/src/main/java/seedu/address/model/person/Memo.java
@@ -19,7 +19,7 @@ public class Memo {
     /** Every character is allowed, up to a maximum of MAXIMUM_CHARACTERS. */
     public static final String VALIDATION_REGEX = ".{0," + MAXIMUM_CHARACTERS + "}";
 
-    /** A empty memo object. */
+    /** An empty memo object. */
     public static final Memo EMPTY_MEMO = new Memo("");
 
     /** String representation of Memo. */
@@ -47,9 +47,9 @@ public class Memo {
     }
 
     /**
-     * Returns true if {@code memo} is empty. False otherwise.
+     * Returns true if {@code memo} is equal to {@code EMPTY_MEMO}, false otherwise.
      *
-     * @return If {@code memo} is empty true; otherwise false.
+     * @return true if {@code memo} is equal to {@code EMPTY_MEMO}; otherwise false.
      */
     public boolean isEmpty() {
         return this.equals(EMPTY_MEMO);

--- a/src/main/java/seedu/address/model/person/Memo.java
+++ b/src/main/java/seedu/address/model/person/Memo.java
@@ -19,6 +19,9 @@ public class Memo {
     /** Every character is allowed, up to a maximum of MAXIMUM_CHARACTERS. */
     public static final String VALIDATION_REGEX = ".{0," + MAXIMUM_CHARACTERS + "}";
 
+    /** A empty memo object. */
+    public static final Memo EMPTY_MEMO = new Memo("");
+
     /** String representation of Memo. */
     public final String memo;
 
@@ -49,7 +52,7 @@ public class Memo {
      * @return If {@code memo} is empty true; otherwise false.
      */
     public boolean isEmpty() {
-        return memo.isEmpty();
+        return this.equals(EMPTY_MEMO);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -92,7 +92,7 @@ public class Person {
     }
 
     /**
-     * Returns if memo is empty.
+     * Returns true if memo is empty, false otherwise.
      *
      * @return If memo is empty true; otherwise false.
      */

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -92,6 +92,15 @@ public class Person {
     }
 
     /**
+     * Returns if memo is empty.
+     *
+     * @return If memo is empty true; otherwise false.
+     */
+    public boolean isMemoEmpty() {
+        return memo.isEmpty();
+    }
+
+    /**
      * Returns true if both persons have same phone number or email.
      * This defines a weaker notion of equality between two persons.
      */
@@ -125,6 +134,7 @@ public class Person {
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
+                && otherPerson.getMemo().equals(getMemo())
                 && otherPerson.getTags().equals(getTags());
     }
 
@@ -136,7 +146,7 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, memo, tags);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -39,9 +39,9 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
-    private FlowPane tags;
+    private HBox memoBox;
     @FXML
-    private Label memo;
+    private FlowPane tags;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -54,7 +54,12 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        memo.setText(person.getMemo().memo);
+
+        if (!person.isMemoEmpty()) {
+            Label memo = new Label(person.getMemo().memo);
+            memoBox.getChildren().add(memo);
+        }
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -4,9 +4,9 @@
 }
 
 .label {
-    -fx-font-size: 11pt;
-    -fx-font-family: "Segoe UI Semibold";
-    -fx-text-fill: #555555;
+    -fx-font-size: 13px;
+    -fx-font-family: "Segoe UI";
+    -fx-text-fill: #010504;
     -fx-opacity: 0.9;
 }
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,7 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="memo" styleClass="cell_small_label" text="\$memo" />
+      <HBox fx:id="memoBox" spacing="5" alignment="CENTER_LEFT" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,42 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "memo": "",
+    "memo": "She likes aardvarks.",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "memo": "",
+    "memo": "He can't take beer!",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "memo": "",
+    "memo": "Works at Google",
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "memo": "",
+    "memo": "Coffee connoisseur",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "memo": "",
+    "memo": "SAF commando officer",
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "memo": "",
+    "memo": "Car enthusiast",
     "tagged" : [ ]
   }, {
     "name" : "George Best",

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAY
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.MEMO_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -80,7 +81,7 @@ public class LogicManagerTest {
 
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY;
+                + ADDRESS_DESC_AMY + MEMO_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMO;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -49,6 +50,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String MEMO_DESC_AMY = " " + PREFIX_MEMO + VALID_MEMO_AMY;
+    public static final String MEMO_DESC_BOB = " " + PREFIX_MEMO + VALID_MEMO_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -10,6 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MEMO_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.MEMO_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -49,36 +51,40 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+
+        // multiple memo - last memo accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + MEMO_DESC_AMY + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
+                + TAG_DESC_HUSBAND + MEMO_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + MEMO_DESC_AMY,
                 new AddCommand(expectedPerson));
     }
 

--- a/src/test/java/seedu/address/logic/parser/ArgumentMultimapTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentMultimapTest.java
@@ -32,18 +32,6 @@ class ArgumentMultimapTest {
         assertTrue(validMultiMap.getValue(validPrefix).isPresent());
     }
 
-
-    @Test
-    void getValueOrEmpty_validArguments() {
-        // When value is null -> should return ""
-        ArgumentMultimap testMap = new ArgumentMultimap();
-        assertEquals(testMap.getValueOrEmpty(validPrefix), "");
-        assertEquals(testMap.getValueOrEmpty(emptyPrefix), "");
-        String testString = "This is a test";
-        testMap.put(validPrefix, testString);
-        assertEquals(testMap.getValueOrEmpty(validPrefix), testString);
-    }
-
     @Test
     void getAllValues_validInputs() {
         ArgumentMultimap testMap = new ArgumentMultimap();
@@ -58,7 +46,6 @@ class ArgumentMultimapTest {
         testMap.put(validPrefix, secondTestString);
         assertEquals(testMap.getAllValues(validPrefix), listOfTestStrings);
     }
-
 
     @Test
     void isEmpty() {

--- a/src/test/java/seedu/address/model/person/MemoTest.java
+++ b/src/test/java/seedu/address/model/person/MemoTest.java
@@ -2,30 +2,76 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.MemoUtil.LONGER_THAN_MAXIMUM_LENGTH_STRING;
+import static seedu.address.testutil.MemoUtil.MAXIMUM_LENGTH_STRING;
+import static seedu.address.testutil.MemoUtil.SHORT_LENGTH_STRING;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains tests for {@code Memo}.
+ */
 public class MemoTest {
+
+    private final String memoStringShort = SHORT_LENGTH_STRING;
+    private final String memoStringMaximum = MAXIMUM_LENGTH_STRING;
+    private final String memoStringLongerThanMaximum = LONGER_THAN_MAXIMUM_LENGTH_STRING;
+
+    private final Memo validShortMemo = new Memo(memoStringShort);
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Memo(null));
+    }
+
+    @Test
+    public void constructor_invalidEmail_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new Memo(memoStringLongerThanMaximum));
+    }
+
+    @Test
+    public void isValidMemo_validShortLengthMemo_returnsTrue() {
+        assertTrue(Memo.isValidMemo(memoStringShort));
+    }
+
+    @Test
+    public void isValidMemo_validMaximumLengthMemo_returnsTrue() {
+        assertTrue(Memo.isValidMemo(memoStringMaximum));
+    }
+
+    @Test
+    public void isValidMemo_invalidLongerThanMaximumLengthMemo_returnsFalse() {
+        assertFalse(Memo.isValidMemo(memoStringLongerThanMaximum));
+    }
+
+    @Test
+    public void isEmpty_nonEmptyMemo_returnsFalse() {
+        assertFalse(validShortMemo.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_emptyMemo_returnsTrue() {
+        assertTrue(Memo.EMPTY_MEMO.isEmpty());
+    }
 
     @Test
     public void equals() {
-        Memo memo = new Memo("Hello");
-
         // same object -> returns true
-        assertTrue(memo.equals(memo));
+        assertTrue(validShortMemo.equals(validShortMemo));
 
         // same values -> returns true
-        Memo memoCopy = new Memo(memo.memo);
-        assertTrue(memo.equals(memoCopy));
+        Memo memoCopy = new Memo(validShortMemo.memo);
+        assertTrue(validShortMemo.equals(memoCopy));
 
         // different types -> returns false
-        assertFalse(memo.equals(1));
+        assertFalse(validShortMemo.equals(1));
 
         // null -> returns false
-        assertFalse(memo.equals(null));
+        assertFalse(validShortMemo.equals(null));
 
         // different memo -> returns false
         Memo differentMemo = new Memo("Bye");
-        assertFalse(memo.equals(differentMemo));
+        assertFalse(validShortMemo.equals(differentMemo));
     }
 }

--- a/src/test/java/seedu/address/testutil/MemoUtil.java
+++ b/src/test/java/seedu/address/testutil/MemoUtil.java
@@ -1,0 +1,32 @@
+package seedu.address.testutil;
+
+import seedu.address.model.person.Memo;
+
+/**
+ * A utility class for Memo.
+ */
+public class MemoUtil {
+
+    /** A short string. */
+    public static final String SHORT_LENGTH_STRING = "hello world";
+
+    /** A long string that is equal to the maximum allowed characters of {@code Memo}. */
+    public static final String MAXIMUM_LENGTH_STRING = getStringOfLength(Memo.MAXIMUM_CHARACTERS);
+
+    /** A long string that is more than the maximum allowed characters of {@code Memo}. */
+    public static final String LONGER_THAN_MAXIMUM_LENGTH_STRING = getStringOfLength(Memo.MAXIMUM_CHARACTERS + 1);
+
+    /**
+     * Returns a string for that of a specified length.
+     *
+     * @param length Length of the string to be created.
+     * @return String of a specified length.
+     */
+    private static String getStringOfLength(int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append('a');
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -2,6 +2,7 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMO;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -34,6 +35,7 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(PREFIX_MEMO + person.getMemo().memo + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -4,6 +4,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEMO_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEMO_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -34,13 +36,14 @@ public class TypicalPersons {
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withMemo("Works at Google").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withMemo("Coffee connoisseur")
+            .withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withMemo("SAF commando officer").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withMemo("Car enthusiast").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street").withMemo("").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
@@ -50,10 +53,11 @@ public class TypicalPersons {
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withMemo(VALID_MEMO_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withMemo(VALID_MEMO_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
Fixes #120

Previous implementation of empty `Memo` is that each `Person` will have their own `Memo` object that is an empty string. Furthermore, if `Memo` is empty, there would be an awkward blank row in the UI.

Update implementation such that all `Person` with empty memos will share the same `EMPTY_MEMO` object and update UI such that if `Memo` is empty, the blank row will not be shown.