### PR TITLE
[#172] Add DeleteTagCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -46,7 +46,9 @@ public class AddCommand extends Command {
     private final Person toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an AddCommand to add the specified {@code Person}.
+     *
+     * @param person Person to be added.
      */
     public AddCommand(Person person) {
         requireNonNull(person);
@@ -77,7 +79,7 @@ public class AddCommand extends Command {
      * Checks if two {@code AddCommand} is equal.
      *
      * @param other the other {@code AddCommand} object.
-     * @return true if equal; otherwise false.
+     * @return If equal true; otherwise false.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -1,0 +1,163 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.ContactedDate;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Memo;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Deletes tags of an existing person in the address book.
+ */
+public class DeleteTagCommand extends Command {
+    public static final String COMMAND_WORD = "deletetag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes the specified tags of the person identified "
+            + "by the index number used in the displayed person list. \n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_TAG + "friend";
+
+    public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted tag: %1$s";
+    public static final String MESSAGE_MISSING_PREFIX = "At least one " + PREFIX_TAG + " must be provided.";
+    public static final String MESSAGE_MISSING_TAG = "%s does not exist in the specified person.";
+
+    private final Index index;
+    private final Set<Tag> tagsToDelete;
+
+    /**
+     * Creates a DeleteTagCommand to delete tags of the person at the specified index with
+     * tagsToDelete.
+     *
+     * @param index Index of the person in the filtered person list to edit.
+     * @param tagsToDelete Tags to delete.
+     */
+    public DeleteTagCommand(Index index, Set<Tag> tagsToDelete) {
+        requireNonNull(index);
+        requireNonNull(tagsToDelete);
+
+        this.index = index;
+        this.tagsToDelete = tagsToDelete;
+    }
+
+    /**
+     * Executes the delete tag command and returns the result message.
+     *
+     * @param model {@code Model} which the delete tag command should operate on.
+     * @return Feedback message of the delete tag operation result for display.
+     * @throws CommandException If an error occurs during delete tag command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Set<Tag> personTags = personToEdit.getTags();
+        Set<Tag> missingTags = findMissingTags(personTags, tagsToDelete);
+
+        if (!missingTags.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_MISSING_TAG, missingTags));
+        }
+
+        Person editedPerson = createEditedPersonWithTagsDeleted(personToEdit, tagsToDelete);
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.saveAddressBookState();
+        return new CommandResult(String.format(MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete));
+    }
+
+    /**
+     * Finds missing tags that are to be deleted but does not exist in personTags.
+     *
+     * @param personTags Tags that belongs to a person.
+     * @param tagsToDelete Tags to delete.
+     * @return A set of tags that contains missing tags that are to be deleted but does not exist in personTags.
+     */
+    private Set<Tag> findMissingTags(Set<Tag> personTags, Set<Tag> tagsToDelete) {
+        Set<Tag> missingTags = new HashSet<>(tagsToDelete);
+        missingTags.removeAll(personTags);
+        return missingTags;
+    }
+
+    /**
+     * Creates an edited {@code Person} with certain tags deleted.
+     *
+     * @param personToEdit {@code Person} to be edited.
+     * @param tagsToDelete Tags to delete.
+     * @return Edited {@code Person} with tags deleted.
+     */
+    private Person createEditedPersonWithTagsDeleted(Person personToEdit, Set<Tag> tagsToDelete) {
+        requireNonNull(personToEdit);
+        requireNonNull(tagsToDelete);
+
+        Name personName = personToEdit.getName();
+        Phone personPhone = personToEdit.getPhone();
+        Email personEmail = personToEdit.getEmail();
+        Address personAddress = personToEdit.getAddress();
+        ContactedDate personContactedDate = personToEdit.getContactedDate();
+        Memo personMemo = personToEdit.getMemo();
+        Set<Tag> personTags = personToEdit.getTags();
+        Set<Tag> updatedTags = createUpdatedTagsWithTagsDeleted(personTags, tagsToDelete);
+        return new Person(personName, personPhone, personEmail, personAddress, personContactedDate, personMemo,
+                updatedTags);
+    }
+
+    /**
+     * Creates a set of tag with certain tags deleted.
+     *
+     * @param personTags Tags belonging to a {@code Person}.
+     * @param tagsToDelete Tags to delete.
+     * @return A set of tag with certain tags deleted.
+     */
+    private Set<Tag> createUpdatedTagsWithTagsDeleted(Set<Tag> personTags, Set<Tag> tagsToDelete) {
+        Set<Tag> updatedTagSet = new HashSet<>(personTags);
+        updatedTagSet.removeAll(tagsToDelete);
+        return updatedTagSet;
+    }
+
+    /**
+     * Checks if two {@code DeleteTagCommand} is equal.
+     *
+     * @param other the other {@code DeleteTagCommand} object.
+     * @return If equal true; otherwise false.
+     */
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteTagCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteTagCommand dt = (DeleteTagCommand) other;
+        return index.equals(dt.index)
+                && tagsToDelete.equals(dt.tagsToDelete);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -61,8 +61,10 @@ public class EditCommand extends Command {
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit.
-     * @param editPersonDescriptor details to edit the person with.
+     * Creates an EditCommand to edit the person at the specified index with editPersonDescriptor.
+     *
+     * @param index Index of the person in the filtered person list to edit.
+     * @param editPersonDescriptor Details to edit the person with.
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
@@ -76,7 +78,7 @@ public class EditCommand extends Command {
      * Executes the edit command and returns the result message.
      *
      * @param model {@code Model} which the edit command should operate on.
-     * @return feedback message of the edit operation result for display.
+     * @return Feedback message of the edit operation result for display.
      * @throws CommandException If an error occurs during edit command execution.
      */
     @Override
@@ -122,6 +124,12 @@ public class EditCommand extends Command {
     }
 
 
+    /**
+     * Checks if two {@code EditCommand} is equal.
+     *
+     * @param other the other {@code EditCommand} object.
+     * @return If equal true; otherwise false.
+     */
     @Override
     public boolean equals(Object other) {
         // short circuit if same object

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -21,7 +21,7 @@ public class RedoCommand extends Command {
             + "(Up to " + StateAddressBook.UNDO_REDO_CAPACITY + " redo)\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_REDO_SUCCESS = "Redo success";
+    public static final String MESSAGE_REDO_SUCCESS = "Redo success!";
     public static final String MESSAGE_REDO_EMPTY = "There is nothing to redo (Max "
             + StateAddressBook.UNDO_REDO_CAPACITY + " redoable actions)";
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -21,7 +21,7 @@ public class UndoCommand extends Command {
             + "(Up to " + StateAddressBook.UNDO_REDO_CAPACITY + " undo)\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_UNDO_SUCCESS = "Undo success";
+    public static final String MESSAGE_UNDO_SUCCESS = "Undo success!";
     public static final String MESSAGE_UNDO_EMPTY = "There is nothing to undo (Max "
             + StateAddressBook.UNDO_REDO_CAPACITY + " undoable actions)";
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -28,7 +28,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new AddCommand object.
  */
 public class AddCommandParser implements Parser<AddCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CopyEmailsCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -121,6 +122,10 @@ public class AddressBookParser {
             requireEmpty(arguments, RedoCommand.MESSAGE_USAGE);
             LOGGER.log(Level.INFO, "Parsed to RedoCommand");
             return new RedoCommand();
+
+        case DeleteTagCommand.COMMAND_WORD:
+            LOGGER.log(Level.INFO, "Parsed to DeleteTagCommand");
+            return new DeleteTagCommandParser().parse(arguments);
 
         default:
             LOGGER.log(Level.INFO, "Unknown command");

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -7,7 +7,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new DeleteCommand object.
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new DeleteTagCommand object.
+ */
+public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
+
+    private static final Logger LOGGER = Logger.getLogger(DeleteTagCommandParser.class.getName());
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteTagCommand
+     * and returns an DeleteTagCommand object for execution.
+     * @throws ParseException If the user input does not conform the expected format.
+     */
+    public DeleteTagCommand parse(String args) throws ParseException {
+        LOGGER.log(Level.INFO, "Executing DeleteTagCommandParser#parse(String)");
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            LOGGER.log(Level.INFO, "Invalid command format");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argMultimap.getValue(PREFIX_TAG).isEmpty()) {
+            LOGGER.log(Level.INFO, "PREFIX_TAG not specified");
+            throw new ParseException(DeleteTagCommand.MESSAGE_MISSING_PREFIX);
+        }
+
+        Set<Tag> tagsToDelete = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        LOGGER.log(Level.INFO, "DeleteTagCommandParser#parse(String) success");
+        return new DeleteTagCommand(index, tagsToDelete);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -25,7 +25,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new EditCommand object
+ * Parses input arguments and creates a new EditCommand object.
  */
 public class EditCommandParser implements Parser<EditCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -13,7 +13,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.predicate.FindPersonPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindCommand object.
  */
 public class FindCommandParser implements Parser<FindCommand> {
     public static final String MESSAGE_INCORRECT_FORMAT = "Only non-negative integer argument is allowed "

--- a/src/main/java/seedu/address/model/person/ContactedDate.java
+++ b/src/main/java/seedu/address/model/person/ContactedDate.java
@@ -15,7 +15,7 @@ import java.time.format.ResolverStyle;
 public class ContactedDate {
 
     /** String message that represents the prefix last contacted on. */
-    public static final String MESSAGE_CONTACTED_PREFIX = "Last contacted on ";
+    public static final String MESSAGE_CONTACTED_PREFIX = "Last contacted on %s";
 
     /** String message that represents not contacted. */
     public static final String MESSAGE_NOT_CONTACTED = "Not contacted";
@@ -107,7 +107,7 @@ public class ContactedDate {
             return MESSAGE_NOT_CONTACTED;
         }
 
-        return MESSAGE_CONTACTED_PREFIX + this.contactedDate;
+        return String.format(MESSAGE_CONTACTED_PREFIX, this.contactedDate);
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,7 +7,7 @@
     "address" : "123, Jurong West Ave 6, #08-111",
     "contactedDate" : "20-03-2022",
     "memo": "She likes aardvarks.",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friend", "colleague", "wife" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -26,6 +26,9 @@ import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
+/**
+ * Contains tests for {@code AddCommand}.
+ */
 public class AddCommandTest {
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -47,6 +47,9 @@ public class CommandTestUtil {
     public static final String VALID_MEMO_BOB = "Favourite pastime: Eating";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_COLLEAGUE = "colleague";
+    public static final String VALID_TAG_WIFE = "wife";
+    public static final String VALID_TAG_COMPANION = "companion";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -1,0 +1,224 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COLLEAGUE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COMPANION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_WIFE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteTagCommand}.
+ */
+public class DeleteTagCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_oneExistingTagSpecifiedUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_COLLEAGUE, VALID_TAG_WIFE).build();
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleExistingTagSpecifiedUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_WIFE).build();
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+        tagsToDelete.add(new Tag(VALID_TAG_COLLEAGUE));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noTagSpecifiedUnfilteredList_success() {
+        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_oneMissingTagSpecifiedUnfilteredList_success() {
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_MISSING_TAG, tagsToDelete);
+
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_twoMissingTagSpecifiedUnfilteredList_success() {
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
+        tagsToDelete.add(new Tag(VALID_TAG_COMPANION));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_MISSING_TAG, tagsToDelete);
+
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_oneMissingTagFollowedByOneExistingTagSpecifiedUnfilteredList_success() {
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        Set<Tag> missingTags = new HashSet<>();
+        missingTags.add(new Tag(VALID_TAG_HUSBAND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_MISSING_TAG, missingTags);
+
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_oneExistingTagFollowedByOneMissingTagSpecifiedUnfilteredList_success() {
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+        tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
+
+        Set<Tag> missingTags = new HashSet<>();
+        missingTags.add(new Tag(VALID_TAG_HUSBAND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_MISSING_TAG, missingTags);
+
+        assertCommandFailure(deleteTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_oneExistingTagSpecifiedFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_COLLEAGUE, VALID_TAG_WIFE).build();
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(outOfBoundIndex, tagsToDelete);
+
+        assertCommandFailure(deleteTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(outOfBoundIndex, tagsToDelete);
+
+        assertCommandFailure(deleteTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        final DeleteTagCommand standardCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+
+        // same values -> returns true
+        Set<Tag> copyTagsToDelete = new HashSet<>(tagsToDelete);
+        DeleteTagCommand commandWithSameValues = new DeleteTagCommand(INDEX_FIRST_PERSON, copyTagsToDelete);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new DeleteTagCommand(INDEX_SECOND_PERSON, tagsToDelete)));
+
+        // different tags to delete -> returns false
+        assertFalse(standardCommand.equals(new DeleteTagCommand(INDEX_SECOND_PERSON, new HashSet<>())));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -30,7 +30,7 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for {@code EditCommand}.
  */
 public class EditCommandTest {
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -48,6 +48,9 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
+/**
+ * Contains tests for {@code AddCommandParser}.
+ */
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,19 +4,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.ARRAY_OF_PREFIX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddTagCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CopyEmailsCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -30,6 +36,7 @@ import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicate.FindPersonPredicate;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -71,6 +78,28 @@ public class AddressBookParserTest {
                 EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                         + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_addTag() throws Exception {
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+
+        AddTagCommand command = (AddTagCommand) parser.parseCommand(
+                AddTagCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
+                        + PREFIX_TAG + VALID_TAG_FRIEND);
+        assertEquals(new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd), command);
+    }
+
+    @Test
+    public void parseCommand_deleteTag() throws Exception {
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand command = (DeleteTagCommand) parser.parseCommand(
+                DeleteTagCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
+                        + PREFIX_TAG + VALID_TAG_FRIEND);
+        assertEquals(new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -56,7 +56,6 @@ public class AddressBookParserTest {
                 ClearCommand.MESSAGE_USAGE), () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
     }
 
-
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -1,0 +1,117 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Contains tests for {@code DeleteTagCommandParse}.
+ */
+public class DeleteTagCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE);
+
+    private DeleteTagCommandParser parser = new DeleteTagCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", DeleteTagCommand.MESSAGE_MISSING_PREFIX);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // overflow max integer
+        assertParseFailure(parser, "2147483648" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidTag_failure() {
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidTagFollowedByValidTag_failure() {
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC + TAG_DESC_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validTagFollowedByInvalidTag_failure() {
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_oneTagSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand expectedCommand = new DeleteTagCommand(targetIndex, tagsToDelete);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleTagsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+        tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
+
+        DeleteTagCommand expectedCommand = new DeleteTagCommand(targetIndex, tagsToDelete);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedTagsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND + TAG_DESC_FRIEND;
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand expectedCommand = new DeleteTagCommand(targetIndex, tagsToDelete);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -55,6 +55,9 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
+/**
+ * Contains tests for {@code EditCommandParser}.
+ */
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
@@ -83,6 +86,9 @@ public class EditCommandParserTest {
 
         // zero index
         assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // overflow max integer
+        assertParseFailure(parser, "2147483648" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -12,8 +12,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COLLEAGUE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_WIFE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +32,7 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withContactedDate("20-03-2022")
-            .withMemo("She likes aardvarks.").withTags("friends").build();
+            .withMemo("She likes aardvarks.").withTags(VALID_TAG_FRIEND, VALID_TAG_COLLEAGUE, VALID_TAG_WIFE).build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withMemo("He can't take beer!")
             .withEmail("johnd@example.com").withPhone("98765432").withContactedDate("01-03-2021")


### PR DESCRIPTION
Fixes #172

Add `DeleteTagCommand` which allows users to delete one or more tags of a specified index in the address book.