### PR TITLE
[#183] Update Person#toString()

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -191,7 +192,9 @@ public class Person {
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");
-            tags.forEach(builder::append);
+            tags.stream()
+                    .sorted(Comparator.comparing(tag -> tag.tagName))
+                    .forEach(tag -> builder.append(String.format("[%s]", tag)));
         }
         return builder.toString();
     }


### PR DESCRIPTION
Fixes #183 

Previous `Person#toString()` appended tags not in sorted order and there was no separator. E.g., if a person has the tags "friends", "colleague", "owesMoney", `Person#toString()` may append the tags as "friendsowesMoneycolleague".

Update `Person#toString()` to append tags in sorted order with brackets as separators, i.e., using the above example, `Person#toString()` will append the tags as "[colleague][friends][owesMoney]".