### PR TITLE
[#191] Update Find Command to allow stricter search conditions

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -375,7 +375,11 @@ Below is a table that shows the matching criteria that is used for each person's
 
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
- Apart from the `c/` prefix, when multiple of the same prefix is specified in the find command, the search result is equivalent to combining the set of results from the first prefix and the set of results from the second prefix. For instance the result that is shown from `find n/alex n/yeoh` is the same as doing a union operation on the set of results from `find n/alex` and `find n/yeoh`. For `c/`, only the input arguments from the last `c/` prefix will be parsed into the find command. For example, `find c/ c/10` would only show contacts that had not been contacted for at least 10 days from the current date.        
+ Apart from the `c/` prefix, when multiple of the same prefix is specified in the find command, the search result is equivalent to combining the set of results from the first prefix and the set of results from the second prefix. In other words, the result that is shown from `find n/alex n/yeoh` is semantically the same as telling ABπ to find all person that has the name "alex" or the name "yeoh". For `c/`, only the input arguments from the last `c/` prefix will be parsed into the find command. For example, `find c/ c/10` would only show contacts that had not been contacted for at least 10 days from the current date.        
+</div>
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+ When multiple different prefixes are specified as arguments for the find command, the search result is equivalent to finding all common results between the different results generated from each individual prefix. In other words, `find n/alex p/9020040` is semantically the same as telling ABπ to find all person that has the name "alex" and the phone number "9020040".
 </div>
 
 <br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -346,20 +346,24 @@ Examples:
 * `find a/street` would match with anybody that has the string "street" in their address.
 * `find m/Lover` would match with anybody that has the string "lover" in their memo.
 * `find c/5` would match with anybody that had not been contacted for more than 5 days relative to the current day.
-*  `find t/Family` would only match with anybody that has a tag that is equivalent to the string "family".
+* `find t/Family` would only match with anybody that has a tag that is equivalent to the string "family".
+* `find t/family e/@example` would only match with anybody that has a tag "family" and an email domain "@example".
 
 
 <br>
 
 <div markdown="span" class="alert alert-info">  
-:information_source: **Note:** For all matching criteria, consecutive whitespaces in the query string is treated as a single whitespace. For example, `find n/Alex_ _ _Yeoh` would be treated as `find n/Alex_Yeoh` where "_" represents a single whitespace in the query string.
+:information_source: **Note:** For all matching criteria, consecutive whitespaces in the query string is treated as a single whitespace. For example, `find n/Alex_ _ _Yeoh` would be treated as `find n/Alex_Yeoh` where "_" represents a single whitespace in the query string. 
 
 <br>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
- Apart from the `c/` prefix,  when there is at least two identical prefix specified in the find command, the search result that is displayed to the user is equivalent to conducting a set union operation on the set of results from the first prefix and the set of results from the subsequent prefixes. For instance the result that is shown from `find n/alex n/yeoh` is the same as doing a union operation on the set of results from `find n/alex` and `find n/yeoh`. For `c/`, only the input parameters from the last `c/` prefix will be used in the find command. For example, `find c/ c/10` would only show contacts that had not been contacted for at least 10 days from the current date.        
+ Apart from the `c/` prefix, when multiple of the same prefix is specified in the find command, the search result is equivalent to combining the set of results from the first prefix and the set of results from the second prefix. In other words, the result that is shown from `find n/alex n/yeoh` is semantically the same as telling ABπ to find all person that has the name "alex" or the name "yeoh". For `c/`, only the input arguments from the last `c/` prefix will be parsed into the find command. For example, `find c/ c/10` would only show contacts that had not been contacted for at least 10 days from the current date.        
 </div>
 
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+ When multiple different prefixes are specified as arguments for the find command, the search result is equivalent to finding all common results between the different results generated from each individual prefix. In other words, `find n/alex p/9020040` is semantically the same as telling ABπ to find all person that has the name "alex" and the phone number "9020040".
+</div>
 
 <br>
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.ARRAY_OF_PREFIX;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,11 +48,12 @@ public class ArgumentMultimap {
 
     /**
      * Returns the list of prefixes in the {@link #argMultimap}.
+     * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.
      *
      * @return Prefixes that are in the user input.
      */
     public List<Prefix> getAllAvailablePrefix() {
-        Set<Prefix> setOfKeys = argMultimap.keySet();
+        Set<Prefix> setOfKeys = new HashSet<>(argMultimap.keySet());
         setOfKeys.remove(new Prefix("")); //removes preamble
         return new ArrayList<>(setOfKeys);
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.FindCommand.NO_PREFIX_MESSAGE;
 import static seedu.address.logic.parser.CliSyntax.ARRAY_OF_PREFIX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMO;
@@ -140,7 +141,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 ParserUtil.parseMemo(value);
             } else if (prefix.equals(PREFIX_TAG)) {
                 ParserUtil.parseTag(value);
-            } else {
+            } else if (prefix.equals(PREFIX_ADDRESS)) {
                 ParserUtil.parseAddress(value);
             }
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,7 +4,13 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.commands.FindCommand.NO_PREFIX_MESSAGE;
 import static seedu.address.logic.parser.CliSyntax.ARRAY_OF_PREFIX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMO;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +77,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             LOGGER.log(Level.INFO, "Input has no valid prefix");
             throw new ParseException(NO_PREFIX_MESSAGE);
         }
+        checkPrefixArgsInProperFormat(argMultimap);
         return argMultimap;
     }
 
@@ -94,6 +101,47 @@ public class FindCommandParser implements Parser<FindCommand> {
                 }
             } catch (NumberFormatException formatException) {
                 throw new ParseException(MESSAGE_INCORRECT_FORMAT);
+            }
+        }
+    }
+
+    /**
+     * Checks if the argument specified by the user is in a proper format and meets the constraints specified by
+     * each individual attributes.
+     *
+     * @param multimap ArgumentMultimap object that contains the arguments specified by the user for the find command.
+     * @throws ParseException If any of the given arguments are invalid.
+     */
+    private void checkPrefixArgsInProperFormat(ArgumentMultimap multimap) throws ParseException {
+        List<Prefix> prefixes = multimap.getAllAvailablePrefix();
+        for (Prefix prefix : prefixes) {
+            checkPrefixArgs(multimap, prefix);
+        }
+    }
+
+    /**
+     * Helper method for @{@link #checkPrefixArgsInProperFormat(ArgumentMultimap)}. Checks if the values in an
+     * ArgumentMultimap object are in a proper format and meets the appropriate attribute constraints.
+     *
+     * @param multimap ArgumentMultimap object that contains the arguments specified by the user for the find command.
+     * @param prefix Prefix required to get the values from the ArgumentMultimap.
+     * @throws ParseException If any of the arguments specified by the user for that specific prefix is invalid.
+     */
+    private void checkPrefixArgs(ArgumentMultimap multimap, Prefix prefix) throws ParseException {
+        List<String> prefixValues = multimap.getAllValues(prefix);
+        for (String value : prefixValues) {
+            if (prefix.equals(PREFIX_NAME)) {
+                ParserUtil.parseName(value);
+            } else if (prefix.equals(PREFIX_EMAIL)) {
+                ParserUtil.parseEmail(value);
+            } else if (prefix.equals(PREFIX_PHONE)) {
+                ParserUtil.parsePhone(value);
+            } else if (prefix.equals(PREFIX_MEMO)) {
+                ParserUtil.parseMemo(value);
+            } else if (prefix.equals(PREFIX_TAG)) {
+                ParserUtil.parseTag(value);
+            } else {
+                ParserUtil.parseAddress(value);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/parser/ScrubCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ScrubCommandParser.java
@@ -46,6 +46,15 @@ public class ScrubCommandParser implements Parser<ScrubCommand> {
         if (argumentMultimap.contains(PREFIX_EMAIL)) {
             checkCorrectEmailFormat(argumentMultimap);
         }
+
+        if (argumentMultimap.contains(PREFIX_TAG)) {
+            checkPrefixArgsInProperFormat(argumentMultimap.getAllValues(PREFIX_TAG), PREFIX_TAG);
+        }
+
+        if (argumentMultimap.contains(PREFIX_PHONE)) {
+            checkPrefixArgsInProperFormat(argumentMultimap.getAllValues(PREFIX_PHONE), PREFIX_PHONE);
+        }
+
         ScrubPersonPredicate predicate = new ScrubPersonPredicate(argumentMultimap);
         return new ScrubCommand(predicate);
     }
@@ -110,6 +119,26 @@ public class ScrubCommandParser implements Parser<ScrubCommand> {
         List<String> emailArgs = argMultimap.getAllValues(PREFIX_EMAIL);
         for (String emailArg : emailArgs) {
             parseDomain(emailArg);
+        }
+    }
+
+    /**
+     * Checks if the argument specified by the user is in a proper format and meets the constraints specified by
+     * each individual attributes.
+     *
+     * @param args List of arguments that belong to the prefix when parsed into the scrub command parser.
+     * @param prefix Prefix that is parsed into the scrub command parser.
+     * @throws ParseException Thrown if any of the arguments of that prefix is in an invalid format.
+     */
+    private void checkPrefixArgsInProperFormat(List<String> args, Prefix prefix) throws ParseException {
+        if (prefix.equals(PREFIX_PHONE)) {
+            for (String phoneStr : args) {
+                ParserUtil.parsePhone(phoneStr);
+            }
+        } else {
+            for (String tagStr : args) {
+                ParserUtil.parseTag(tagStr);
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/model/person/predicate/FindPersonPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicate/FindPersonPredicate.java
@@ -52,11 +52,11 @@ public class FindPersonPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         List<Prefix> prefixes = descriptor.getAllAvailablePrefix();
         for (Prefix prefix : prefixes) {
-            if (testPersonAttribute(person, prefix)) {
-                return true;
+            if (!testPersonAttribute(person, prefix)) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/predicate/ScrubPersonPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicate/ScrubPersonPredicate.java
@@ -39,7 +39,7 @@ public class ScrubPersonPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         List<Prefix> listOfPrefixes = argMultimap.getAllAvailablePrefix();
-        return listOfPrefixes.stream().anyMatch(prefix -> createPredicate(prefix).test(person));
+        return listOfPrefixes.stream().allMatch(prefix -> createPredicate(prefix).test(person));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -10,7 +10,6 @@ import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -45,16 +45,13 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        String emptyInput = "n/tester";
+    public void execute_zeroKeywords_allPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 7);
+        String emptyInput = " n/";
         ArgumentMultimap emptyDescriptor = ArgumentTokenizer.tokenize(emptyInput, ARRAY_OF_PREFIX);
         FindCommand command = new FindCommand(new FindPersonPredicate(emptyDescriptor));
         expectedModel.updateFilteredPersonList(new FindPersonPredicate(emptyDescriptor));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-
-        // Since it is an empty predicate, it should return 0 person found
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -48,19 +48,6 @@ public class FindCommandParserTest {
         // Max positive integer values -> parse successful.
         String argWithMaxPositiveInteger = " c/2147483647";
         assertParseSuccess(parser, argWithMaxPositiveInteger, prepareFindCommand(argWithMaxPositiveInteger));
-
-        // Blank argument -> parse successful.
-        String contactedDateArgWithNoArgument = " n/";
-        assertParseSuccess(parser, contactedDateArgWithNoArgument, prepareFindCommand(contactedDateArgWithNoArgument));
-
-        // Multiple blank argument -> parse successful.
-        String multipleBlankArg = "n/ e/ p/ a/ t/ m/ c/";
-        assertParseSuccess(parser, multipleBlankArg, prepareFindCommand(multipleBlankArg));
-
-        // Special characters in Find -> parse successful.
-        String specialCharactersArg = " n/! e/@ p/`";
-        assertParseSuccess(parser, specialCharactersArg, prepareFindCommand(specialCharactersArg));
-
     }
 
     /**

--- a/src/test/java/seedu/address/model/person/predicate/FindPersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicate/FindPersonPredicateTest.java
@@ -17,12 +17,12 @@ class FindPersonPredicateTest {
     void test_validPerson_returnsTrue() {
         ArgumentMultimap descriptor = ArgumentTokenizer.tokenize(" n/alex t/colleague p/9040", ARRAY_OF_PREFIX);
         FindPersonPredicate predicate = new FindPersonPredicate(descriptor);
-        assertTrue(predicate.test(new PersonBuilder().withName("a").withPhone("90400204").build()));
-        assertTrue(predicate.test(new PersonBuilder().withName("Alex Yeoh").withPhone("123").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("alexa").withPhone("90400204").withTags("colleague").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alexa").withPhone("90402").withTags("colleague").build()));
     }
 
     @Test
-    void test_invalidCases_returnsFalse() {
+    void test_negativeCases_returnsFalse() {
         ArgumentMultimap descriptor = ArgumentTokenizer.tokenize(" a/streets t/colleague p/9040", ARRAY_OF_PREFIX);
         FindPersonPredicate predicate = new FindPersonPredicate(descriptor);
         assertFalse(predicate.test(new PersonBuilder().withAddress("street").withPhone("904").build()));

--- a/src/test/java/seedu/address/model/person/predicate/FindPersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicate/FindPersonPredicateTest.java
@@ -15,15 +15,19 @@ class FindPersonPredicateTest {
 
     @Test
     void test_validPerson_returnsTrue() {
-        ArgumentMultimap descriptor = ArgumentTokenizer.tokenize(" n/alex t/colleague p/9040", ARRAY_OF_PREFIX);
+        ArgumentMultimap descriptor = ArgumentTokenizer
+                .tokenize(" n/alex t/colleague p/9040", ARRAY_OF_PREFIX);
         FindPersonPredicate predicate = new FindPersonPredicate(descriptor);
-        assertTrue(predicate.test(new PersonBuilder().withName("alexa").withPhone("90400204").withTags("colleague").build()));
-        assertTrue(predicate.test(new PersonBuilder().withName("Alexa").withPhone("90402").withTags("colleague").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("alexa").withPhone("90400204")
+                .withTags("colleague").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alexa")
+                .withPhone("90402").withTags("colleague").build()));
     }
 
     @Test
     void test_negativeCases_returnsFalse() {
-        ArgumentMultimap descriptor = ArgumentTokenizer.tokenize(" a/streets t/colleague p/9040", ARRAY_OF_PREFIX);
+        ArgumentMultimap descriptor = ArgumentTokenizer
+                .tokenize(" a/streets t/colleague p/9040", ARRAY_OF_PREFIX);
         FindPersonPredicate predicate = new FindPersonPredicate(descriptor);
         assertFalse(predicate.test(new PersonBuilder().withAddress("street").withPhone("904").build()));
         assertFalse(predicate.test(new PersonBuilder().withName("a").withPhone("123").withTags("colle").build()));

--- a/src/test/java/seedu/address/model/person/predicate/ScrubPersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicate/ScrubPersonPredicateTest.java
@@ -19,15 +19,18 @@ class ScrubPersonPredicateTest {
         ArgumentMultimap multipleArgDescriptor = ArgumentTokenizer.tokenize(" e/@mail e/@gmail p/90400204 p/90400203 "
                 + "t/tag1 t/tag2", ARRAY_OF_PREFIX);
         ScrubPersonPredicate singleArgPredicate = new ScrubPersonPredicate(singleArgDescriptor);
-        assertTrue(singleArgPredicate.test(new PersonBuilder().withEmail("tester@mail.com").build()));
-        assertTrue(singleArgPredicate.test(new PersonBuilder().withPhone("90400204").build()));
-        assertTrue(singleArgPredicate.test(new PersonBuilder().withTags("tag1").build()));
+        assertTrue(singleArgPredicate.test(new PersonBuilder().withEmail("tester@mail.com").withTags("tag1")
+                .withPhone("90400204").build()));
+        assertFalse(singleArgPredicate.test(new PersonBuilder().withEmail("tester@mail.com").build()));
+        assertFalse(singleArgPredicate.test(new PersonBuilder().withPhone("90400204").build()));
+        assertFalse(singleArgPredicate.test(new PersonBuilder().withTags("tag1").build()));
         assertFalse(singleArgPredicate.test(new PersonBuilder().withTags("tag22").build()));
 
         ScrubPersonPredicate multipleArgPredicate = new ScrubPersonPredicate(multipleArgDescriptor);
-        assertTrue(multipleArgPredicate.test(new PersonBuilder().withEmail("tester@gmail.com").build()));
-        assertTrue(multipleArgPredicate.test(new PersonBuilder().withPhone("90400203").build()));
-        assertTrue(multipleArgPredicate.test(new PersonBuilder().withTags("tag2").build()));
+        assertTrue(multipleArgPredicate.test(new PersonBuilder().withEmail("tester@gmail.com")
+                .withPhone("90400204").withTags("tag2").build()));
+        assertFalse(multipleArgPredicate.test(new PersonBuilder().withPhone("90400203").build()));
+        assertFalse(multipleArgPredicate.test(new PersonBuilder().withTags("tag2").build()));
 
         ArgumentMultimap multipleTagDescriptor = ArgumentTokenizer.tokenize("t/tag1 t/tag2", ARRAY_OF_PREFIX);
         ScrubPersonPredicate multipleTagPredicate = new ScrubPersonPredicate(multipleTagDescriptor);


### PR DESCRIPTION
Fixes #191.

Change conditions such that `find p/999 n/alex` is semantically the same as finding all contacts with phone number 999 AND with the name Alex.