### PR TITLE
[#207] Improve error message for incorrect date

### DIFF
--- a/src/main/java/seedu/address/model/person/ContactedDate.java
+++ b/src/main/java/seedu/address/model/person/ContactedDate.java
@@ -31,7 +31,7 @@ public class ContactedDate {
             .withResolverStyle(ResolverStyle.STRICT);
 
     /** String message that represents message constraints. */
-    public static final String MESSAGE_CONSTRAINTS = "Last contacted date either be empty or "
+    public static final String MESSAGE_CONSTRAINTS = "Last contacted date can either be empty or "
             + "a VALID date following the dd-mm-yyyy format that is not in the future.";
 
     /** A static {@code contactedDate} object that represents an empty contacted date. */

--- a/src/main/java/seedu/address/model/person/ContactedDate.java
+++ b/src/main/java/seedu/address/model/person/ContactedDate.java
@@ -31,8 +31,8 @@ public class ContactedDate {
             .withResolverStyle(ResolverStyle.STRICT);
 
     /** String message that represents message constraints. */
-    public static final String MESSAGE_CONSTRAINTS = "ContactedDate can be empty or "
-            + "a valid date following the dd-mm-yyyy format that is not in the future.";
+    public static final String MESSAGE_CONSTRAINTS = "Last contacted date either be empty or "
+            + "a VALID date following the dd-mm-yyyy format that is not in the future.";
 
     /** A static {@code contactedDate} object that represents an empty contacted date. */
     public static final ContactedDate EMPTY_CONTACTED_DATE = new ContactedDate("");


### PR DESCRIPTION
Fixes #207

Improved the message constraint when a user enters a `ContactedDate` in the wrong format.