### PR TITLE
[#222][#224][#225] Revamp equals for Person and person attributes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -182,7 +182,8 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO]
 
 <div markdown="span" class="alert alert-info">  
 
-:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. For example "John &nbsp&nbsp&nbsp Doe" will be trimmed to "John Doe".
+:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
+For example "John    Doe" will be trimmed to "John Doe".
 
 </div>
 
@@ -218,7 +219,8 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 
 <div markdown="span" class="alert alert-info">  
 
-:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. For example "John &nbsp&nbsp&nbsp Doe" will be trimmed to "John Doe".
+:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
+For example "John    Doe" will be trimmed to "John Doe".
 
 </div>
 
@@ -506,9 +508,9 @@ Abπ helps to manage duplicates by preventing duplicate entries of identical nam
 
 <div markdown="span" class="alert alert-info">  
 
-:information_source: **Note:** For phone numbers, it has to be identical to be considered equal. For example: 
-- "+65 98765432" is considered different from "65 98765432" (difference in "+").
-- "+65 98765432" is considered different from "+6598765432" (difference in whitespace).
+:information_source: **Note:** For phone numbers, it has to be identical to be considered equal. For example: <br>
+ "+65 98765432" is considered different from "65 98765432" (difference in "+") <br>
+ "+65 98765432" is considered different from "+6598765432" (difference in whitespace)
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -215,7 +215,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
 
 <div markdown="span" class="alert alert-info">
-:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
+:information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
 For example, "John &#160;&#160;&#160; Doe" will be trimmed to "John Doe".
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -181,8 +181,8 @@ Adds a person to the address book.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-info">
-:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, using “_” to represent a single whitespace, "John___Doe" will be trimmed to "John_Doe".
+:information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
+For example, using "_" to represent a single whitespace, "John_ _ _Doe" will be trimmed to "John_Doe".
 </div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
@@ -217,7 +217,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 
 <pre markdown="span" class="alert alert-info">
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, using “_” to represent a single whitespace, "John___Doe" will be trimmed to "John_Doe".
+For example, using "_" to represent a single whitespace, "John_ _ _Doe" will be trimmed to "John_Doe".
 </pre>
 
 Examples:
@@ -507,10 +507,10 @@ Abπ helps to manage duplicates by preventing duplicate entries of identical nam
 For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
 <br>
 For all person attributes, if whitespace is allowed, a difference in white space is considered as different. For example: <br>
-    "John Doe" is different from "JohnDoe" <br>
+    "John Doe" is different from "JohnDoe". <br>
 <br>
- For phone numbers, it has to be identical to be considered equal. For example: <br>
- "+65 98765432" is considered different from "65 98765432" (difference in "+")
+ For phone, it has to be identical to be considered equal. For example: <br>
+ "+65 98765432" is considered different from "65 98765432" (difference in "+").
 </div>
 
 #### 4.9.2. Saving the data

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -183,7 +183,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO]
 <div markdown="span" class="alert alert-info">  
 
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example "John    Doe" will be trimmed to "John Doe".
+For example <pre>"John    Doe" </pre>will be trimmed to "John Doe".
 
 </div>
 
@@ -220,7 +220,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 <div markdown="span" class="alert alert-info">  
 
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example "John    Doe" will be trimmed to "John Doe".
+For example <pre>"John    Doe" </pre> will be trimmed to "John Doe".
 
 </div>
 
@@ -508,9 +508,11 @@ Abπ helps to manage duplicates by preventing duplicate entries of identical nam
 
 <div markdown="span" class="alert alert-info">  
 
-:information_source: **Note:** For phone numbers, it has to be identical to be considered equal. For example: <br>
- "+65 98765432" is considered different from "65 98765432" (difference in "+") <br>
- "+65 98765432" is considered different from "+6598765432" (difference in whitespace)
+:information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
+For all person attributes, if whitespace is allowed, a difference in white space is considered as different. For example: <br>
+    "John Doe" is different from "JohnDoe" <br>
+ For phone numbers, it has to be identical to be considered equal. For example: <br>
+ "+65 98765432" is considered different from "65 98765432" (difference in "+") 
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -178,7 +178,13 @@ This section will bring you through the Graphical User Interface (GUI) of Abπ.
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED_DATE] [m/MEMO] [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO] [t/TAG]…​`
+
+<div markdown="span" class="alert alert-info">  
+
+:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. For example "John &nbsp&nbsp&nbsp Doe" will be trimmed to "John Doe".
+
+</div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
  Contacted Date, Memo, and Tag are optional.
@@ -209,6 +215,12 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
 * You can remove all the person’s tags or memo by typing `t/` or `m/` respectively without specifying text after it.
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
+
+<div markdown="span" class="alert alert-info">  
+
+:information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. For example "John &nbsp&nbsp&nbsp Doe" will be trimmed to "John Doe".
+
+</div>
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -491,6 +503,14 @@ Format: `exit`
 
 #### 4.9.1. Preventing duplicate entries
 Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email. The reason why duplicate is considered as such is to provide greater flexibility as different individuals may share the same name, or phone, or even email.
+
+<div markdown="span" class="alert alert-info">  
+
+:information_source: **Note:** For phone numbers, it has to be identical to be considered equal. For example: 
+- "+65 98765432" is considered different from "65 98765432" (difference in "+").
+- "+65 98765432" is considered different from "+6598765432" (difference in whitespace).
+
+</div>
 
 #### 4.9.2. Saving the data
 Abπ data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -182,7 +182,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO]
 
 <div markdown="span" class="alert alert-info">
 :information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, using "_" to represent a single whitespace, "John_ _ _Doe" will be trimmed to "John_Doe".
+For example, using '_' to represent a single whitespace, 'John_ _ _Doe' will be trimmed to 'John_Doe'.
 </div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
@@ -215,10 +215,10 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * You can remove all the person’s tags or memo by typing `t/` or `m/` respectively without specifying text after it.
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
 
-<pre markdown="span" class="alert alert-info">
+<div markdown="span" class="alert alert-info">
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, using "_" to represent a single whitespace, "John_ _ _Doe" will be trimmed to "John_Doe".
-</pre>
+For example, using '_' to represent a single whitespace, 'John_ _ _Doe' will be trimmed to 'John_Doe'.
+</div>
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -507,10 +507,10 @@ Abπ helps to manage duplicates by preventing duplicate entries of identical nam
 For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
 <br>
 For all person attributes, if whitespace is allowed, a difference in white space is considered as different. For example: <br>
-    "John Doe" is different from "JohnDoe". <br>
+    "John Doe" is different from "JohnDoe" <br>
 <br>
  For phone, it has to be identical to be considered equal. For example: <br>
- "+65 98765432" is considered different from "65 98765432" (difference in "+").
+ "+65 98765432" is considered different from "65 98765432" (difference in "+")
 </div>
 
 #### 4.9.2. Saving the data

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -43,7 +43,7 @@ AddressBook pi (Abπ) is a **360° all-rounded desktop app for managing contacts
 &nbsp;&nbsp;&nbsp;&nbsp;[4.8.1. Viewing help](#481-viewing-help-help) <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;[4.8.2. Exiting the program](#482-exiting-the-program-exit) <br/>
 &nbsp;&nbsp;[4.9. Extra information regarding the features](#49-extra-information-regarding-the-features) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.1. Preventing duplicate entries (phone and email)](#491-preventing-duplicate-entries-phone-and-email) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.1. Preventing duplicate entries](#491-preventing-duplicate-entries) <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;[4.9.2. Saving the data](#492-saving-the-data) <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;[4.9.3. Editing the data file](#493-editing-the-data-file) <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;[4.9.4. Predictive viewing](#494-predictive-viewing) <br/>
@@ -489,8 +489,8 @@ Format: `exit`
 
 ### 4.9. Extra information regarding the features
 
-#### 4.9.1. Preventing duplicate entries (phone and email) 
-Abπ helps to manage duplicates by preventing duplicate entries of phone number and email when using the add and edit commands. All phone numbers and emails in Abπ will be unique.
+#### 4.9.1. Preventing duplicate entries
+Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email. The reason why duplicate is considered as such is to provide flexibility as individuals may share the same name, or phone, or even email.
 
 #### 4.9.2. Saving the data
 Abπ data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -216,7 +216,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 
 <div markdown="span" class="alert alert-info">
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, 'John &nbsp;&nbsp;&nbsp; Doe' will be trimmed to 'John_Doe'.
+For example, "John &#160;&#160;&#160; Doe" will be trimmed to "John Doe".
 </div>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -496,7 +496,7 @@ Abπ helps to remove accidental extra white spaces between words to provide a cl
 
 Examples:
 * "John &#160;&#160;&#160;&#160;&#160; Doe" will be trimmed to "John Doe".
-* "Likes &#160;&#160;&#160; to &#160;&#160;&#160;&#160;&#160; drink" will be trimmed to "Likes to drink".
+* "Likes &#160;&#160;&#160; to &#160;&#160;&#160; drink" will be trimmed to "Likes to drink".
 
 #### 4.9.2. Preventing duplicate entries
 Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. 
@@ -507,11 +507,11 @@ Abπ helps to manage duplicates by preventing duplicate entries of identical nam
 <div markdown="span" class="alert alert-info">
 :information_source: **Note:** <br>
 For all person attributes a difference in white space is considered as different. For example: <br>
-&#160; "John Doe" is different from "JohnDoe" <br>
-&#160; "65 98765432" is different from "6598765432" <br>
+"John Doe" is different from "JohnDoe" <br>
+"65 98765432" is different from "6598765432" <br>
 <br>
 For phone, a difference in "+" is also considered as different. For example: <br>
-&#160; "+65 98765432" is considered different from "65 98765432"
+"+65 98765432" is considered different from "65 98765432"
  
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -212,11 +212,11 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
 
 Examples:
-* `edit 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-* `edit 2 n/Betsy Crower t/` edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
-* `edit 2 m/Avid free climber` edits the memo of the 2nd person to be `Avid free climber`.
-* `edit 2 c/01-01-2020` edits the contacted date of the 2nd person to be `Last contacted on 01-01-2020`.
-* `edit 2 m/ c/` edits the memo of the 2nd person to be empty and the contacted date to be `Not contacted`.
+* `edit 1 n/John Doe p/91234567 e/johndoe@example.com` edits the name, phone number and email address of the 1st person to be "John Doe", "91234567" and "johndoe@example.com" respectively.
+* `edit 2 t/` edits the 2nd person to clear all existing tags.
+* `edit 2 t/friends t/colleagues` edits the 2nd person which overwrites all existing tags with the tags "friends" and "colleagues".
+* `edit 2 c/01-01-2020` edits the contacted date of the 2nd person to be "Last contacted on 01-01-2020".
+* `edit 2 m/ c/` edits the memo of the 2nd person to be empty and the contacted date to be "Not contacted".
 
 [Back to Table of Contents](#table-of-contents-br)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -43,10 +43,11 @@ AddressBook pi (Abπ) is a **360° all-rounded desktop app for managing contacts
 &nbsp;&nbsp;&nbsp;&nbsp;[4.8.1. Viewing help](#481-viewing-help-help) <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;[4.8.2. Exiting the program](#482-exiting-the-program-exit) <br/>
 &nbsp;&nbsp;[4.9. Extra information regarding the features](#49-extra-information-regarding-the-features) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.1. Preventing duplicate entries](#491-preventing-duplicate-entries) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.2. Saving the data](#492-saving-the-data) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.3. Editing the data file](#493-editing-the-data-file) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.4. Predictive viewing](#494-predictive-viewing) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.1. Trimming of extra white spaces](#491-trimming-of-extra-white-spaces) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.2. Preventing duplicate entries](#492-preventing-duplicate-entries) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.3. Saving the data](#493-saving-the-data) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.4. Editing the data file](#494-editing-the-data-file) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.5. Predictive viewing](#495-predictive-viewing) <br/>
 [5. FAQ](#5-faq) <br/>
 [6. Command Summary](#6-command-summary) <br/>
 
@@ -165,7 +166,7 @@ This section will bring you through the Graphical User Interface (GUI) of Abπ.
 
 * If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence of the parameter will be taken. e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 
-* Commands that do not take in parameters (`help`, `list`, `copyemails`, `undo`, `redo`, `previous`, `next`, `clear`, `exit`) must match the command format exactly, otherwise it will not be recognized. This is to protect from accidental invocations of the wrong command. e.g. if you want to delete the first person and mistakenly call `clear 1` instead of `delete 1`, it will be interpreted as an invalid command to protect you from accidentally clearing the entire address book unintentionally. The proper format is to execute clear is just `clear`.
+* Commands that do not take in parameters (`help`, `list`, `copyemails`, `undo`, `redo`, `previous`, `next`, `clear`, `exit`) must match the command format exactly, otherwise it will not be recognized. This is to protect from accidental invocations of the wrong command. e.g. if you want to delete the first person and mistakenly call `clear 1` instead of `delete 1`, it will be interpreted as an invalid command to protect you from accidentally clearing the entire address book unintentionally. The proper format to execute clear is just `clear`.
 
 </div>
 
@@ -178,11 +179,6 @@ This section will bring you through the Graphical User Interface (GUI) of Abπ.
 Adds a person to the address book.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO] [t/TAG]…​`
-
-<div markdown="span" class="alert alert-info">
-:information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, "John &#160;&#160;&#160; Doe" will be trimmed to "John Doe".
-</div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
  Contacted Date, Memo, and Tag are optional.
@@ -213,11 +209,6 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
 * You can remove all the person’s tags or memo by typing `t/` or `m/` respectively without specifying text after it.
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
-
-<div markdown="span" class="alert alert-info">
-:information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, "John &#160;&#160;&#160; Doe" will be trimmed to "John Doe".
-</div>
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -498,24 +489,36 @@ Format: `exit`
 
 ### 4.9. Extra information regarding the features
 
-#### 4.9.1. Preventing duplicate entries
-Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email. The reason why duplicate is considered as such is to provide greater flexibility as different individuals may share the same name, or phone, or even email.
+#### 4.9.1. Trimming of extra white spaces
+Abπ helps to remove accidental extra white spaces between words to provide a cleaner experience. 
+
+* For name, phone, address, memo, and tag, extra white spaces (2 or more) between words will be replaced with a single white space. <br>
+
+Examples:
+* "John &#160;&#160;&#160;&#160;&#160; Doe" will be trimmed to "John Doe".
+* "Likes &#160;&#160;&#160; to &#160;&#160;&#160;&#160;&#160; drink" will be trimmed to "Likes to drink".
+
+#### 4.9.2. Preventing duplicate entries
+Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. 
+
+* Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email.
+* The reason why duplicate is considered as such is to provide greater flexibility as different individuals may share the same name, or phone, or even email.
 
 <div markdown="span" class="alert alert-info">
-:information_source: **Note:** <br> 
-For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
+:information_source: **Note:** <br>
+For all person attributes a difference in white space is considered as different. For example: <br>
+&#160; "John Doe" is different from "JohnDoe" <br>
+&#160; "65 98765432" is different from "6598765432" <br>
 <br>
-For all person attributes, if whitespace is allowed, a difference in white space is considered as different. For example: <br>
-    "John Doe" is different from "JohnDoe" <br>
-<br>
- For phone, it has to be identical to be considered equal. For example: <br>
- "+65 98765432" is considered different from "65 98765432" (difference in "+")
+For phone, a difference in "+" is also considered as different. For example: <br>
+&#160; "+65 98765432" is considered different from "65 98765432"
+ 
 </div>
 
-#### 4.9.2. Saving the data
+#### 4.9.3. Saving the data
 Abπ data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
 
-#### 4.9.3. Editing the data file
+#### 4.9.4. Editing the data file
 
 Abπ data are saved as a JSON file `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing that data file.
 
@@ -523,7 +526,7 @@ Abπ data are saved as a JSON file `[JAR file location]/data/addressbook.json`. 
  If your changes to the data file makes its format invalid, AddressBook will discard all data and start with an empty data file at the next run.
 </div>
 
-#### 4.9.4. Predictive viewing
+#### 4.9.5. Predictive viewing
 
 Abπ will pre-emptively update the display after various commands:
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -490,7 +490,7 @@ Format: `exit`
 ### 4.9. Extra information regarding the features
 
 #### 4.9.1. Preventing duplicate entries
-Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email. The reason why duplicate is considered as such is to provide flexibility as individuals may share the same name, or phone, or even email.
+Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email. The reason why duplicate is considered as such is to provide greater flexibility as different individuals may share the same name, or phone, or even email.
 
 #### 4.9.2. Saving the data
 Abπ data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -180,11 +180,9 @@ Adds a person to the address book.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO] [t/TAG]…​`
 
-<div markdown="span" class="alert alert-info">  
-
+<div markdown="span" class="alert alert-info">
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example <pre> "John    Doe" </pre> will be trimmed to "John Doe".
-
+For example, using “_” to represent a single whitespace, "John___Doe" will be trimmed to "John_Doe".
 </div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
@@ -217,11 +215,9 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * You can remove all the person’s tags or memo by typing `t/` or `m/` respectively without specifying text after it.
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
 
-<pre markdown="span" class="alert alert-info">  
-
+<pre markdown="span" class="alert alert-info">
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example "John    Doe" will be trimmed to "John Doe".
-
+For example, using “_” to represent a single whitespace, "John___Doe" will be trimmed to "John_Doe".
 </pre>
 
 Examples:
@@ -506,8 +502,7 @@ Format: `exit`
 #### 4.9.1. Preventing duplicate entries
 Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email. The reason why duplicate is considered as such is to provide greater flexibility as different individuals may share the same name, or phone, or even email.
 
-<div markdown="span" class="alert alert-info">  
-
+<div markdown="span" class="alert alert-info">
 :information_source: **Note:** <br> 
 For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
 <br>
@@ -515,8 +510,7 @@ For all person attributes, if whitespace is allowed, a difference in white space
     "John Doe" is different from "JohnDoe" <br>
 <br>
  For phone numbers, it has to be identical to be considered equal. For example: <br>
- "+65 98765432" is considered different from "65 98765432" (difference in "+") 
-
+ "+65 98765432" is considered different from "65 98765432" (difference in "+")
 </div>
 
 #### 4.9.2. Saving the data

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -183,7 +183,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO]
 <div markdown="span" class="alert alert-info">  
 
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example <pre>"John    Doe" </pre>will be trimmed to "John Doe".
+For example <pre> "John    Doe" </pre> will be trimmed to "John Doe".
 
 </div>
 
@@ -217,12 +217,12 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * You can remove all the person’s tags or memo by typing `t/` or `m/` respectively without specifying text after it.
 * You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
 
-<div markdown="span" class="alert alert-info">  
+<pre markdown="span" class="alert alert-info">  
 
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example <pre>"John    Doe" </pre> will be trimmed to "John Doe".
+For example "John    Doe" will be trimmed to "John Doe".
 
-</div>
+</pre>
 
 Examples:
 * `edit 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
@@ -508,9 +508,12 @@ Abπ helps to manage duplicates by preventing duplicate entries of identical nam
 
 <div markdown="span" class="alert alert-info">  
 
-:information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
+:information_source: **Note:** <br> 
+For name and phone, extra white spaces (2 or more) between words/numbers will be treated as a single white space. <br>
+<br>
 For all person attributes, if whitespace is allowed, a difference in white space is considered as different. For example: <br>
     "John Doe" is different from "JohnDoe" <br>
+<br>
  For phone numbers, it has to be identical to be considered equal. For example: <br>
  "+65 98765432" is considered different from "65 98765432" (difference in "+") 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -43,11 +43,12 @@ AddressBook pi (Abπ) is a **360° all-rounded desktop app for managing contacts
 &nbsp;&nbsp;&nbsp;&nbsp;[4.8.1. Viewing help](#481-viewing-help-help) <br/>
 &nbsp;&nbsp;&nbsp;&nbsp;[4.8.2. Exiting the program](#482-exiting-the-program-exit) <br/>
 &nbsp;&nbsp;[4.9. Extra information regarding the features](#49-extra-information-regarding-the-features) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.1. Trimming of extra white spaces](#491-trimming-of-extra-white-spaces) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.2. Preventing duplicate entries](#492-preventing-duplicate-entries) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.3. Saving the data](#493-saving-the-data) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.4. Editing the data file](#494-editing-the-data-file) <br/>
-&nbsp;&nbsp;&nbsp;&nbsp;[4.9.5. Predictive viewing](#495-predictive-viewing) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.1. Ignoring case difference](#491-ignoring-case-difference) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.2. Trimming of extra white spaces](#492-trimming-of-extra-white-spaces) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.3. Preventing duplicate entries](#493-preventing-duplicate-entries) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.4. Saving the data](#494-saving-the-data) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.5. Editing the data file](#495-editing-the-data-file) <br/>
+&nbsp;&nbsp;&nbsp;&nbsp;[4.9.6. Predictive viewing](#496-predictive-viewing) <br/>
 [5. FAQ](#5-faq) <br/>
 [6. Command Summary](#6-command-summary) <br/>
 
@@ -248,10 +249,11 @@ Format: `deletetag INDEX t/TAG…`
 
 * Deletes one or more tags of the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * If any of the tag to be deleted does not exist, the command will be rejected.
+* If `deletetag` is successful, the success display message will be based on the user's input. That is, if `deletetag 1 t/FRIENDS` is executed successfully and the tag "friends" (different capitalization) is deleted, "Deleted tag: [FRIENDS]" will be displayed.
 
 Examples:
-* `deletetag 1 t/friends` deletes the tag "friends" of the 1st person if the tag exists.
-* `deletetag 2 t/colleagues t/friends` deletes the tag "colleagues" and "friends" of the 2nd person if both tags exist.
+* `deletetag 1 t/friends` deletes the tag "friends" of the 1st person in the displayed list if the tag exists.
+* `deletetag 2 t/colleagues t/friends` deletes the tag "colleagues" and "friends" of the 2nd person in the displayed list if both tags exist.
 
 [Back to Table of Contents](#table-of-contents-br)
 
@@ -489,7 +491,16 @@ Format: `exit`
 
 ### 4.9. Extra information regarding the features
 
-#### 4.9.1. Trimming of extra white spaces
+#### 4.9.1. Ignoring case difference
+Abπ ignores case difference for the person attributes `Name`, `Email`, `Address`, `Memo` and `Tag` to provide a more seamless experience that matches the real world.
+* Attributes that only differs in case sensitivity is considered as identical.
+
+Examples:
+
+* "John Doe" and "john doe" is considered as the same name.
+* "LIKES TO DRINK" and "likes to drink" is considered as the same tag.
+
+#### 4.9.2. Trimming of extra white spaces
 Abπ helps to remove accidental extra white spaces between words to provide a cleaner experience. 
 
 * For name, phone, address, memo, and tag, extra white spaces (2 or more) between words will be replaced with a single white space. <br>
@@ -498,7 +509,7 @@ Examples:
 * "John &#160;&#160;&#160;&#160;&#160; Doe" will be trimmed to "John Doe".
 * "Likes &#160;&#160;&#160; to &#160;&#160;&#160; drink" will be trimmed to "Likes to drink".
 
-#### 4.9.2. Preventing duplicate entries
+#### 4.9.3. Preventing duplicate entries
 Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. 
 
 * Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email.
@@ -515,10 +526,10 @@ For phone, a difference in "+" is also considered as different. For example: <br
  
 </div>
 
-#### 4.9.3. Saving the data
+#### 4.9.4. Saving the data
 Abπ data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
 
-#### 4.9.4. Editing the data file
+#### 4.9.5. Editing the data file
 
 Abπ data are saved as a JSON file `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing that data file.
 
@@ -526,7 +537,7 @@ Abπ data are saved as a JSON file `[JAR file location]/data/addressbook.json`. 
  If your changes to the data file makes its format invalid, AddressBook will discard all data and start with an empty data file at the next run.
 </div>
 
-#### 4.9.5. Predictive viewing
+#### 4.9.6. Predictive viewing
 
 Abπ will pre-emptively update the display after various commands:
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -139,7 +139,6 @@ _For more information on Java, click [here](https://www.oracle.com/java/technolo
 * Intel-based Mac running Mac OS X 10.8.3+, 10.9+
 * Administrator privileges for installation
 
-
 <div style="page-break-after: always;"></div>
 
 ## 3. About
@@ -182,7 +181,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO]
 
 <div markdown="span" class="alert alert-info">
 :information_source: **Note:** For name and phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, using '_' to represent a single whitespace, 'John_ _ _Doe' will be trimmed to 'John_Doe'.
+For example, "John &#160;&#160;&#160; Doe" will be trimmed to "John Doe".
 </div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
@@ -217,7 +216,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 
 <div markdown="span" class="alert alert-info">
 :information_source: **Note:** For Name and Phone, extra white spaces (2 or more) between words/numbers will be replaced with a single white space. <br> 
-For example, using '_' to represent a single whitespace, 'John_ _ _Doe' will be trimmed to 'John_Doe'.
+For example, 'John &nbsp;&nbsp;&nbsp; Doe' will be trimmed to 'John_Doe'.
 </div>
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -40,8 +40,8 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This phone number or "
-            + "email already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person's name, phone and email "
+            + "already exists in the address book.";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -111,16 +111,15 @@ public class DeleteTagCommand extends Command {
         requireNonNull(personToEdit);
         requireNonNull(tagsToDelete);
 
-        Name personName = personToEdit.getName();
-        Phone personPhone = personToEdit.getPhone();
-        Email personEmail = personToEdit.getEmail();
-        Address personAddress = personToEdit.getAddress();
-        ContactedDate personContactedDate = personToEdit.getContactedDate();
-        Memo personMemo = personToEdit.getMemo();
-        Set<Tag> personTags = personToEdit.getTags();
-        Set<Tag> updatedTags = createUpdatedTagsWithTagsDeleted(personTags, tagsToDelete);
-        return new Person(personName, personPhone, personEmail, personAddress, personContactedDate, personMemo,
-                updatedTags);
+        Name name = personToEdit.getName();
+        Phone phone = personToEdit.getPhone();
+        Email email = personToEdit.getEmail();
+        Address address = personToEdit.getAddress();
+        ContactedDate contactedDate = personToEdit.getContactedDate();
+        Memo memo = personToEdit.getMemo();
+        Set<Tag> tags = personToEdit.getTags();
+        Set<Tag> updatedTags = createUpdatedTagsWithTagsDeleted(tags, tagsToDelete);
+        return new Person(name, phone, email, address, contactedDate, memo, updatedTags);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -54,8 +54,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This phone number or "
-            + "email already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person's name, phone and email "
+            + "already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -93,7 +93,7 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (model.hasPersonExcept(editedPerson, personToEdit)) {
+        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -46,6 +46,10 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
+
+        // Replaces 2 or more consecutive whitespaces between words with a single whitespace.
+        trimmedName = trimmedName.replaceAll("\\s{2,}", " ");
+
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -61,6 +65,10 @@ public class ParserUtil {
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
+
+        // Replaces 2 or more consecutive whitespaces between numbers with a single whitespace.
+        trimmedPhone = trimmedPhone.replaceAll("\\s{2,}", " ");
+
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -46,10 +46,7 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
-
-        // Replaces 2 or more consecutive whitespaces between words with a single whitespace.
-        trimmedName = trimmedName.replaceAll("\\s{2,}", " ");
-
+        trimmedName = trimExtraWhiteSpaces(trimmedName);
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -65,10 +62,7 @@ public class ParserUtil {
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
-
-        // Replaces 2 or more consecutive whitespaces between numbers with a single whitespace.
-        trimmedPhone = trimmedPhone.replaceAll("\\s{2,}", " ");
-
+        trimmedPhone = trimExtraWhiteSpaces(trimmedPhone);
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
@@ -84,6 +78,7 @@ public class ParserUtil {
     public static Address parseAddress(String address) throws ParseException {
         requireNonNull(address);
         String trimmedAddress = address.trim();
+        trimmedAddress = trimExtraWhiteSpaces(trimmedAddress);
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
         }
@@ -132,6 +127,7 @@ public class ParserUtil {
     public static Memo parseMemo(String memo) throws ParseException {
         requireNonNull(memo);
         String trimmedMemo = memo.trim();
+        trimmedMemo = trimExtraWhiteSpaces(trimmedMemo);
         if (!Memo.isValidMemo(trimmedMemo)) {
             throw new ParseException(Memo.MESSAGE_CONSTRAINTS);
         }
@@ -150,6 +146,7 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
+        trimmedTag = trimExtraWhiteSpaces(trimmedTag);
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
@@ -166,6 +163,16 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Replaces 2 or more consecutive whitespaces between words with a single whitespace.
+     *
+     * @param str String to be trimmed.
+     * @return Trimmed string with extra whitespaces removed.
+     */
+    private static String trimExtraWhiteSpaces(String str) {
+        return str.replaceAll("\\s{2,}", " ");
     }
 
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -60,12 +60,6 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
-     * Returns true if a person with the same identity as {@code person} exists in the address book,
-     * excluding {@code except}.
-     */
-    boolean hasPersonExcept(Person person, Person except);
-
-    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -102,17 +102,6 @@ public class ModelManager implements Model {
         return stateAddressBook.hasPerson(person);
     }
 
-    /**
-     * Returns true if a person with the same identity as {@code person} exists in the address book,
-     * excluding {@code except}.
-     */
-    @Override
-    public boolean hasPersonExcept(Person person, Person except) {
-        requireNonNull(person);
-        requireNonNull(except);
-        return stateAddressBook.hasPersonExcept(person, except);
-    }
-
     @Override
     public void deletePerson(Person target) {
         stateAddressBook.removePerson(target);

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -48,12 +48,12 @@ public class Address {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Address // instanceof handles nulls
-                && address.equals(((Address) other).address)); // state check
+                && address.equalsIgnoreCase(((Address) other).address)); // state check
     }
 
     @Override
     public int hashCode() {
-        return address.hashCode();
+        return address.toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -62,12 +62,12 @@ public class Email {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Email // instanceof handles nulls
-                && email.equals(((Email) other).email)); // state check
+                && email.equalsIgnoreCase(((Email) other).email)); // state check
     }
 
     @Override
     public int hashCode() {
-        return email.hashCode();
+        return email.toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Memo.java
+++ b/src/main/java/seedu/address/model/person/Memo.java
@@ -75,7 +75,7 @@ public class Memo {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Memo // instanceof handles nulls
-                && memo.equals(((Memo) other).memo)); // state check
+                && memo.equalsIgnoreCase(((Memo) other).memo)); // state check
     }
 
     /**
@@ -85,6 +85,6 @@ public class Memo {
      */
     @Override
     public int hashCode() {
-        return memo.hashCode();
+        return memo.toLowerCase().hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -51,12 +51,12 @@ public class Name {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                && fullName.equalsIgnoreCase(((Name) other).fullName)); // state check
     }
 
     @Override
     public int hashCode() {
-        return fullName.hashCode();
+        return fullName.toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -114,11 +114,11 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same phone or email.
+     * Returns true if both persons have the same name, phone and email.
      * This defines a weaker notion of equality between two persons.
      *
      * @param otherPerson The other {@code Person}.
-     * @return true if both persons have the same phone or email; otherwise false.
+     * @return true if both persons have the same name, phone and email.
      */
     public boolean isSamePerson(Person otherPerson) {
         if (otherPerson == this) {
@@ -126,7 +126,9 @@ public class Person {
         }
 
         return otherPerson != null
-                && (otherPerson.getPhone().equals(getPhone()) || otherPerson.getEmail().equals(getEmail()));
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone())
+                && otherPerson.getEmail().equals(getEmail());
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -37,12 +37,12 @@ public class Tag {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Tag // instanceof handles nulls
-                && tagName.equals(((Tag) other).tagName)); // state check
+                && tagName.equalsIgnoreCase(((Tag) other).tagName)); // state check
     }
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return tagName.toLowerCase().hashCode();
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -8,9 +8,9 @@
     "memo": "Avid hiker",
     "tagged": [ "friends" ]
   }, {
-    "name": "Alice Pauline",
+    "name": "alice pauline",
     "phone": "94351253",
-    "email": "pauline@example.com",
+    "email": "alice@example.com",
     "address": "4th street",
     "contactedDate": "12-12-2021",
     "memo": ""

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -4,9 +4,10 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTACTED_DATE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEMO_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -59,36 +60,48 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_differentNameDuplicatePhone_throwsCommandException() {
+    public void execute_differentAddressDuplicateNamePhoneEmail_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        // Duplicate phone number.
-        Person invalidPerson = new PersonBuilder().withName(VALID_NAME_BOB).withEmail(VALID_EMAIL_BOB).build();
+        // Different address, duplicate name, phone and email.
+        Person invalidPerson = new PersonBuilder().withAddress(VALID_ADDRESS_BOB).build();
         AddCommand addCommand = new AddCommand(invalidPerson);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
     }
 
     @Test
-    public void execute_differentNameDuplicateEmail_throwsCommandException() {
+    public void execute_differentContactedDateDuplicateNamePhoneEmail_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        // Duplicate email.
-        Person invalidPerson = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).build();
+        // Different contacted date, duplicate name, phone and email.
+        Person invalidPerson = new PersonBuilder().withContactedDate(VALID_CONTACTED_DATE_BOB).build();
         AddCommand addCommand = new AddCommand(invalidPerson);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
     }
 
     @Test
-    public void execute_differentNameDuplicatePhoneAndEmail_throwsCommandException() {
+    public void execute_differentMemoDuplicateNamePhoneEmail_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        // Duplicate email.
-        Person invalidPerson = new PersonBuilder().withName(VALID_NAME_BOB).build();
+        // Different memo, duplicate name, phone and email.
+        Person invalidPerson = new PersonBuilder().withMemo(VALID_MEMO_BOB).build();
+        AddCommand addCommand = new AddCommand(invalidPerson);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_differentTagsDuplicateNamePhoneEmail_throwsCommandException() {
+        Person validPerson = new PersonBuilder().build();
+        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+
+        // Different tags, duplicate name, phone and email.
+        Person invalidPerson = new PersonBuilder().withTags(VALID_TAG_FRIEND).build();
         AddCommand addCommand = new AddCommand(invalidPerson);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
@@ -169,11 +182,6 @@ public class AddCommandTest {
 
         @Override
         public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPersonExcept(Person person, Person except) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -83,7 +83,7 @@ public class CommandTestUtil {
             + PREFIX_CONTACTED_DATE + "11 Dec 2021";
 
     // exceeds the maximum number of characters allowed for memo
-    public static final String INVALID_MEMO_DESC = " " + PREFIX_MEMO + MemoUtil.LONGER_THAN_MAXIMUM_MEMO_STRING;
+    public static final String INVALID_MEMO_DESC = " " + PREFIX_MEMO + MemoUtil.ONE_MORE_THAN_MAXIMUM_MEMO_STRING;
 
     // '*' not allowed in tags
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -96,7 +96,7 @@ public class DeleteCommandTest {
         // null -> returns false
         assertFalse(deleteFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different delete command -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -15,7 +15,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -15,6 +15,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,24 @@ public class DeleteTagCommandTest {
 
         Set<Tag> tagsToDelete = new HashSet<>();
         tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
+
+        DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
+        String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_oneExistingTagDifferentCapitalizationSpecifiedUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_COLLEAGUE, VALID_TAG_WIFE).build();
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        tagsToDelete.add(new Tag(VALID_TAG_FRIEND.toUpperCase()));
 
         DeleteTagCommand deleteTagCommand = new DeleteTagCommand(INDEX_FIRST_PERSON, tagsToDelete);
         String expectedMessage = String.format(DeleteTagCommand.MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete);
@@ -90,7 +109,7 @@ public class DeleteTagCommandTest {
     }
 
     @Test
-    public void execute_oneMissingTagSpecifiedUnfilteredList_success() {
+    public void execute_oneMissingTagSpecifiedUnfilteredList_failure() {
         Set<Tag> tagsToDelete = new HashSet<>();
         tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
 
@@ -101,7 +120,7 @@ public class DeleteTagCommandTest {
     }
 
     @Test
-    public void execute_twoMissingTagSpecifiedUnfilteredList_success() {
+    public void execute_twoMissingTagSpecifiedUnfilteredList_failure() {
         Set<Tag> tagsToDelete = new HashSet<>();
         tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
         tagsToDelete.add(new Tag(VALID_TAG_COMPANION));
@@ -113,7 +132,7 @@ public class DeleteTagCommandTest {
     }
 
     @Test
-    public void execute_oneMissingTagFollowedByOneExistingTagSpecifiedUnfilteredList_success() {
+    public void execute_oneMissingTagFollowedByOneExistingTagSpecifiedUnfilteredList_failure() {
         Set<Tag> tagsToDelete = new HashSet<>();
         tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));
         tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
@@ -128,7 +147,7 @@ public class DeleteTagCommandTest {
     }
 
     @Test
-    public void execute_oneExistingTagFollowedByOneMissingTagSpecifiedUnfilteredList_success() {
+    public void execute_oneExistingTagFollowedByOneMissingTagSpecifiedUnfilteredList_failure() {
         Set<Tag> tagsToDelete = new HashSet<>();
         tagsToDelete.add(new Tag(VALID_TAG_FRIEND));
         tagsToDelete.add(new Tag(VALID_TAG_HUSBAND));

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -177,22 +177,14 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_duplicatePhoneUnfilteredList_failure() {
+    public void execute_duplicateNamePhoneEmailUnFilteredList_failure() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(secondPerson)
-                .withPhone(firstPerson.getPhone().toString()).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
-
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
-    }
-
-    @Test
-    public void execute_duplicateEmailUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(secondPerson)
-                .withEmail(firstPerson.getEmail().toString()).build();
+                .withName(firstPerson.getName().toString())
+                .withPhone(firstPerson.getPhone().toString())
+                .withEmail(firstPerson.getEmail().toString())
+                .build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
@@ -271,7 +263,7 @@ public class EditCommandTest {
     public void execute_duplicatePersonFilteredList_failure() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        // edit person in filtered list into a duplicate in address book.
+        // edit person in filtered list into a duplicate in the address book.
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(personInList).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
@@ -280,28 +272,17 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_duplicatePhoneFilteredList_failure() {
+    public void execute_duplicateNamePhoneEmailFilteredList_failure() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        // edit person in filtered list into a duplicate (phone) in address book.
+        // edit person in filtered list into a duplicate (name, phone and email) in the address book.
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         EditPersonDescriptor descriptor =
-                new EditPersonDescriptorBuilder(firstPerson).withPhone(personInList.getPhone().toString()).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
-    }
-
-    @Test
-    public void execute_duplicateEmailFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        // edit person in filtered list into a duplicate (email) in address book.
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditPersonDescriptor descriptor =
-                new EditPersonDescriptorBuilder(firstPerson).withEmail(personInList.getEmail().toString()).build();
+                new EditPersonDescriptorBuilder(firstPerson).withName(personInList.getName().toString())
+                        .withPhone(personInList.getPhone().toString())
+                        .withEmail(personInList.getEmail().toString())
+                        .build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -29,7 +29,7 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_CONTACTED_DATE = "01/01/2022";
-    private static final String INVALID_MEMO = MemoUtil.LONGER_THAN_MAXIMUM_MEMO_STRING;
+    private static final String INVALID_MEMO = MemoUtil.ONE_MORE_THAN_MAXIMUM_MEMO_STRING;
     private static final String INVALID_TAG = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -33,4 +35,32 @@ public class AddressTest {
         assertTrue(Address.isValidAddress("-")); // one character
         assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
     }
+
+    @Test
+    public void equals() {
+
+        Address validAddressAmy = new Address(VALID_ADDRESS_AMY);
+        Address validAddressBob = new Address(VALID_ADDRESS_BOB);
+
+        // same object -> returns true
+        assertTrue(validAddressAmy.equals(validAddressAmy));
+
+        // same values -> returns true
+        Address validAddressAmyCopy = new Address(VALID_ADDRESS_AMY);
+        assertTrue(validAddressAmy.equals(validAddressAmyCopy));
+
+        // different capitalization -> returns true
+        Address validAddressAmyAllCaps = new Address(VALID_ADDRESS_AMY.toUpperCase());
+        assertTrue(validAddressAmy.equals(validAddressAmyAllCaps));
+
+        // different types -> returns false
+        assertFalse(validAddressAmy.equals(1));
+
+        // null -> returns false
+        assertFalse(validAddressAmy.equals(null));
+
+        // different address -> returns false
+        assertFalse(validAddressAmy.equals(validAddressBob));
+    }
+
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -76,4 +78,32 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
         assertTrue(Email.isValidEmail(edgeEmail)); // super long email
     }
+
+    @Test
+    public void equals() {
+
+        Email validEmailAmy = new Email(VALID_EMAIL_AMY);
+        Email validEmailBob = new Email(VALID_EMAIL_BOB);
+
+        // same object -> returns true
+        assertTrue(validEmailAmy.equals(validEmailAmy));
+
+        // same values -> returns true
+        Email validEmailAmyCopy = new Email(VALID_EMAIL_AMY);
+        assertTrue(validEmailAmy.equals(validEmailAmyCopy));
+
+        // different capitalization -> returns true
+        Email validEmailAmyAllCaps = new Email(VALID_EMAIL_AMY.toUpperCase());
+        assertTrue(validEmailAmy.equals(validEmailAmyAllCaps));
+
+        // different types -> returns false
+        assertFalse(validEmailAmy.equals(1));
+
+        // null -> returns false
+        assertFalse(validEmailAmy.equals(null));
+
+        // different email -> returns false
+        assertFalse(validEmailAmy.equals(validEmailBob));
+    }
+
 }

--- a/src/test/java/seedu/address/model/person/MemoTest.java
+++ b/src/test/java/seedu/address/model/person/MemoTest.java
@@ -2,10 +2,12 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEMO_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEMO_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.MemoUtil.LONGER_THAN_MAXIMUM_MEMO_STRING;
 import static seedu.address.testutil.MemoUtil.MAXIMUM_MEMO_STRING;
-import static seedu.address.testutil.MemoUtil.SHORT_LENGTH_STRING;
+import static seedu.address.testutil.MemoUtil.ONE_LESS_THAN_MAXIMUM_MEMO_STRING;
+import static seedu.address.testutil.MemoUtil.ONE_MORE_THAN_MAXIMUM_MEMO_STRING;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +16,7 @@ import org.junit.jupiter.api.Test;
  */
 public class MemoTest {
 
-    private final Memo validShortMemo = new Memo(SHORT_LENGTH_STRING);
+    private final Memo validMemoAmy = new Memo(VALID_MEMO_AMY);
 
     @Test
     public void constructor_null_throwsNullPointerException() {
@@ -23,12 +25,17 @@ public class MemoTest {
 
     @Test
     public void constructor_invalidMemo_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> new Memo(LONGER_THAN_MAXIMUM_MEMO_STRING));
+        assertThrows(IllegalArgumentException.class, () -> new Memo(ONE_MORE_THAN_MAXIMUM_MEMO_STRING));
     }
 
     @Test
     public void isValidMemo_validShortLengthMemo_returnsTrue() {
-        assertTrue(Memo.isValidMemo(SHORT_LENGTH_STRING));
+        assertTrue(Memo.isValidMemo(VALID_MEMO_AMY));
+    }
+
+    @Test
+    public void isValidMemo_validOneLessThanMaximumLengthMemo_returnsTrue() {
+        assertTrue(Memo.isValidMemo(ONE_LESS_THAN_MAXIMUM_MEMO_STRING));
     }
 
     @Test
@@ -37,13 +44,13 @@ public class MemoTest {
     }
 
     @Test
-    public void isValidMemo_invalidLongerThanMaximumLengthMemo_returnsFalse() {
-        assertFalse(Memo.isValidMemo(LONGER_THAN_MAXIMUM_MEMO_STRING));
+    public void isValidMemo_invalidOneMoreThanMaximumLengthMemo_returnsFalse() {
+        assertFalse(Memo.isValidMemo(ONE_MORE_THAN_MAXIMUM_MEMO_STRING));
     }
 
     @Test
     public void isEmpty_notEmptyValidMemo_returnsFalse() {
-        assertFalse(validShortMemo.isEmpty());
+        assertFalse(validMemoAmy.isEmpty());
     }
 
     @Test
@@ -54,20 +61,24 @@ public class MemoTest {
     @Test
     public void equals() {
         // same object -> returns true
-        assertTrue(validShortMemo.equals(validShortMemo));
+        assertTrue(validMemoAmy.equals(validMemoAmy));
 
         // same values -> returns true
-        Memo memoCopy = new Memo(validShortMemo.memo);
-        assertTrue(validShortMemo.equals(memoCopy));
+        Memo validMemoCopy = new Memo(validMemoAmy.memo);
+        assertTrue(validMemoAmy.equals(validMemoCopy));
+
+        // different capitalization -> returns true
+        Memo validMemoAmyAllCaps = new Memo(VALID_MEMO_AMY);
+        assertTrue(validMemoAmy.equals(validMemoAmyAllCaps));
 
         // different types -> returns false
-        assertFalse(validShortMemo.equals(1));
+        assertFalse(validMemoAmy.equals(1));
 
         // null -> returns false
-        assertFalse(validShortMemo.equals(null));
+        assertFalse(validMemoAmy.equals(null));
 
         // different memo -> returns false
-        Memo differentMemo = new Memo("Bye");
-        assertFalse(validShortMemo.equals(differentMemo));
+        Memo differentMemo = new Memo(VALID_MEMO_BOB);
+        assertFalse(validMemoAmy.equals(differentMemo));
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -41,4 +43,32 @@ public class NameTest {
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd"));
         assertTrue(Name.isValidName(edgeName)); //long name
     }
+
+    @Test
+    public void equals() {
+
+        Name validNameAmy = new Name(VALID_NAME_AMY);
+        Name validNameBob = new Name(VALID_NAME_BOB);
+
+        // same object -> returns true
+        assertTrue(validNameAmy.equals(validNameAmy));
+
+        // same values -> returns true
+        Name validNameAmyCopy = new Name(VALID_NAME_AMY);
+        assertTrue(validNameAmy.equals(validNameAmyCopy));
+
+        // different capitalization -> returns true
+        Name validNameAmyAllCaps = new Name(VALID_NAME_AMY.toUpperCase());
+        assertTrue(validNameAmy.equals(validNameAmyAllCaps));
+
+        // different types -> returns false
+        assertFalse(validNameAmy.equals(1));
+
+        // null -> returns false
+        assertFalse(validNameAmy.equals(null));
+
+        // different name -> returns false
+        assertFalse(validNameAmy.equals(validNameBob));
+    }
+
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -36,8 +36,13 @@ public class PersonTest {
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns true
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // same name amd phone, all other attributes different -> returns false
+        editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // same name, phone and email, all other attributes different -> returns true
+        editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns true
@@ -48,10 +53,6 @@ public class PersonTest {
         editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB).build();
         assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns true
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -40,5 +42,28 @@ public class PhoneTest {
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+    }
+
+    @Test
+    public void equals() {
+
+        Phone validPhoneAmy = new Phone(VALID_PHONE_AMY);
+        Phone validPhoneBob = new Phone(VALID_PHONE_BOB);
+
+        // same object -> returns true
+        assertTrue(validPhoneAmy.equals(validPhoneAmy));
+
+        // same values -> returns true
+        Phone validPhoneAmyCopy = new Phone(VALID_PHONE_AMY);
+        assertTrue(validPhoneAmy.equals(validPhoneAmyCopy));
+
+        // different types -> returns false
+        assertFalse(validPhoneAmy.equals(1));
+
+        // null -> returns false
+        assertFalse(validPhoneAmy.equals(null));
+
+        // different phone -> returns false
+        assertFalse(validPhoneAmy.equals(validPhoneBob));
     }
 }

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -2,6 +2,8 @@ package seedu.address.model.tag;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COLLEAGUE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,33 @@ public class TagTest {
         assertTrue(Tag.isValidTagName("Capital")); // with capital letters
         assertTrue(Tag.isValidTagName("李白")); // only non-alphanumeric characters
         assertTrue(Tag.isValidTagName(edgeTag)); // long Tags
+    }
+
+    @Test
+    public void equals() {
+
+        Tag validTagFriend = new Tag(VALID_TAG_FRIEND);
+        Tag validTagColleague = new Tag(VALID_TAG_COLLEAGUE);
+
+        // same object -> returns true
+        assertTrue(validTagFriend.equals(validTagFriend));
+
+        // same values -> returns true
+        Tag validTagFriendCopy = new Tag(VALID_TAG_FRIEND);
+        assertTrue(validTagFriend.equals(validTagFriendCopy));
+
+        // different capitalization -> returns true
+        Tag validTagFriendAllCaps = new Tag(VALID_TAG_FRIEND.toUpperCase());
+        assertTrue(validTagFriend.equals(validTagFriendAllCaps));
+
+        // different types -> returns false
+        assertFalse(validTagFriend.equals(1));
+
+        // null -> returns false
+        assertFalse(validTagFriend.equals(null));
+
+        // different tag -> returns false
+        assertFalse(validTagFriend.equals(validTagColleague));
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -26,7 +26,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_CONTACTED_DATE = "11 Dec 2021";
-    private static final String INVALID_MEMO = MemoUtil.LONGER_THAN_MAXIMUM_MEMO_STRING;
+    private static final String INVALID_MEMO = MemoUtil.ONE_MORE_THAN_MAXIMUM_MEMO_STRING;
     private static final String INVALID_TAG = "  ";
 
     private static final String VALID_NAME = BENSON.getName().fullName;

--- a/src/test/java/seedu/address/testutil/MemoUtil.java
+++ b/src/test/java/seedu/address/testutil/MemoUtil.java
@@ -7,14 +7,14 @@ import seedu.address.model.person.Memo;
  */
 public class MemoUtil {
 
-    /** A short string. */
-    public static final String SHORT_LENGTH_STRING = "hello world";
+    /** A long string that is one less than the maximum allowed characters of {@code Memo}. */
+    public static final String ONE_LESS_THAN_MAXIMUM_MEMO_STRING = getStringOfLength(Memo.MAXIMUM_CHARACTERS - 1);
 
     /** A long string that is equal to the maximum allowed characters of {@code Memo}. */
     public static final String MAXIMUM_MEMO_STRING = getStringOfLength(Memo.MAXIMUM_CHARACTERS);
 
-    /** A long string that is more than the maximum allowed characters of {@code Memo}. */
-    public static final String LONGER_THAN_MAXIMUM_MEMO_STRING = getStringOfLength(Memo.MAXIMUM_CHARACTERS + 1);
+    /** A long string that is one more than the maximum allowed characters of {@code Memo}. */
+    public static final String ONE_MORE_THAN_MAXIMUM_MEMO_STRING = getStringOfLength(Memo.MAXIMUM_CHARACTERS + 1);
 
     /**
      * Returns a string for that of a specified length.


### PR DESCRIPTION
Fixes #222, Fixes #224, Fixes #225

Previous `Person#equal()` is true if phone or email is the same. This means that all contacts in the address book have unique phone and unique email. This is decided to be too restrictive.

Update `Person#equal()` to be true only if name, phone, email are the same. This allows greater flexibility in the address book, i.e., contacts are only considered as duplicates if name, phone and email are identical.  The following changes are made:
1. Update `Person#equal()` to be true only if name, phone and email are identical.
2. Update `#equal()` of `Name`, `Email`, `Address`, `Memo`, `Tag` to ignore case difference.
3. Update `#hasCode()` of `Name`, `Email`, `Address`, `Memo`, `Tag` with `String#toLowerCase()`.
4. Update test cases for `Person`, `AddCommand`, `EditCommand`.
5. Add `#equal()` test cases for `Name`, `Phone`, `Email`, `Address`, `Memo`, `Tag`.
6. Update `Name`, `Phone`, `Address`, `Memo`, `Tag` such that extra white spaces between words will be trimmed to one white space.
7. Update the `Preventing Duplicate entries` section of `UserGuide.md` and added a `Trimming of extra white spaces` section.

The updates made in 2. also fixes #222 and #225.