### PR TITLE
[#221] Update UserGuide.md to indicate how to remove all tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -249,7 +249,9 @@ Format: `deletetag INDEX t/TAG…`
 * Deletes one or more tags of the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * If any of the tag to be deleted does not exist, the command will be rejected.
 
+<div markdown="block" class="alert alert-info">
 :information_source: **Note:** To overwrite all existing tags or remove all tags, refer to [4.1.2. Editing a person](#412-editing-a-person-edit).
+</div>
 
 Examples:
 * `deletetag 1 t/friends` deletes the tag "friends" of the 1st person if the tag exists.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -249,9 +249,7 @@ Format: `deletetag INDEX t/TAG…`
 * Deletes one or more tags of the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * If any of the tag to be deleted does not exist, the command will be rejected.
 
-<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
- To overwrite all existing tags or remove all tags, refer to [4.1.2. Editing a person](#412-editing-a-person-edit)
-</div>
+:information_source: **Note:** To overwrite all existing tags or remove all tags, refer to [4.1.2. Editing a person](#412-editing-a-person-edit).
 
 Examples:
 * `deletetag 1 t/friends` deletes the tag "friends" of the 1st person if the tag exists.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -249,6 +249,10 @@ Format: `deletetag INDEX t/TAG…`
 * Deletes one or more tags of the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * If any of the tag to be deleted does not exist, the command will be rejected.
 
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+ To overwrite all existing tags or remove all tags, refer to [4.1.2. Editing a person](#412-editing-a-person-edit)
+</div>
+
 Examples:
 * `deletetag 1 t/friends` deletes the tag "friends" of the 1st person if the tag exists.
 * `deletetag 2 t/colleagues t/friends` deletes the tag "colleagues" and "friends" of the 2nd person if both tags exist.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -250,7 +250,7 @@ Format: `deletetag INDEX t/TAG…`
 * If any of the tag to be deleted does not exist, the command will be rejected.
 
 <div markdown="block" class="alert alert-info">
-:information_source: **Note:** To overwrite all existing tags or remove all tags, refer to [4.1.2. Editing a person](#412-editing-a-person-edit).
+:information_source: **Note:** To overwrite all existing tags or remove all tags in one go, refer to [4.1.2. Editing a person](#412-editing-a-person-edit).
 </div>
 
 Examples:


### PR DESCRIPTION
Fixes #221

Add a note to the `Deleting tags of a person` section of `UserGuide.md` to indicate how to remove all tags via the `Editing a person` section.