### PR TITLE
[#219] Update documentation for Undo and Redo

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -184,7 +184,7 @@ This section describes some noteworthy details on how certain features are imple
 
 ### 4.1. Undo and redo feature
 
-The address book undo and redo mechanism is managed by `StateAddressBook`, which extends `AddressBook`. It keeps track of the address book state history, stored internally as a `stateHistory` and `currentStateIndex`. `currentStateIndex` points to the current state of the address book. The number of undoable and redoable actions is capped by `UNDO_REDO_CAPACITY`, currently set to 20. Additionally, it implements the following operations:
+The address book undo and redo mechanism is managed by `StateAddressBook`, which extends `AddressBook`. It keeps track of the address book state history, stored internally as a `stateHistory` and `currentStateIndex`. `currentStateIndex` points to the current state of the address book. The number of undoable and redoable actions is capped by `UNDO_REDO_CAPACITY`, currently set to 10. Additionally, it implements the following operations:
 
 * `StateAddressBook#undo()` — Restores the address book to its previous state.
 * `StateAddressBook#redo()` — Restores the address book to a previously undid state.
@@ -199,7 +199,7 @@ These operations are exposed in the `Model` interface respectively as
 * `Model#canUndoAddressBook()`
 * `Model#canRedoAddressBook()`
 
-Commands that do not modify the address book states will not call `Model#saveAddressBookState()`. The address book undo and redo mechanism only tracks commands that modify the address book state, the commands that are undoable and redoable are `add`, `edit`, `delete`, `clear` and `scrub`.
+Commands that do not modify the address book states will not call `Model#saveAddressBookState()`. The address book undo and redo mechanism only tracks commands that modify the address book state, the commands that are undoable and redoable are `add`, `edit`, `delete`, `clear`, `scrub`, `addtag` and `deletetag`.
 
 Given below is an example usage scenario and how undo and redo mechanism behaves at each step. For demonstration, `UNDO_REDO_CAPACITY` is set to 3.
 
@@ -275,7 +275,7 @@ The following activity diagram summarizes what happens when a user executes a ne
 * **Current implementation:** Saves the entire address book.
     * Pros: Easy to implement.
     * Cons: May have performance issues in terms of memory usage.
-    * Workaround: Limit the number of undoable and redoable actions, using `UNDO_REDO_CAPACITY`. Currently, it is set to 20.
+    * Workaround: Limit the number of undoable and redoable actions, using `UNDO_REDO_CAPACITY`. Currently, it is set to 10.
 
 * **Alternative:** Individual command knows how to undo and redo by itself.
     * Pros: `stateHistory` will use less memory. E.g. for `delete` it only needs to save the person being deleted.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -424,9 +424,11 @@ Examples:
 
 #### 4.7.1. Undoing commands: `undo`
 
-Undo previous commands that modified data, which includes: `add`, `edit`, `delete`, `clear` and `scrub`.
+Undo previous commands that modified data, which includes: `add`, `edit`, `delete`, `clear`, `scrub`, `addtag` and `deletetag`.
 
 Format: `undo`
+
+- The maximum number of undo is 10.
 
 Examples:
 * `undo` after calling `delete 1` restores the address book to its previous state prior to the deletion.
@@ -441,6 +443,8 @@ Examples:
 Redo reverses the `undo` command.
 
 Format: `redo`
+
+The maximum number of redo is 10.
 
 Examples:
 * `redo` after calling `undo` restores the address book to its previous state prior to undo.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -181,14 +181,16 @@ Adds a person to the address book.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED DATE] [m/MEMO] [t/TAG]…​`
 
-* If contacted date is specified, it must follow the dd-mm-yyyy format, cannot be in the future and must be a valid [AD](https://en.wikipedia.org/wiki/Anno_Domini) date. For both invalid date and incorrect format, the same error message will be shown to indicate that the date needs to be valid, following the proper format.
-
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
  Contacted date, memo, and tag are optional.
 </div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
  A person can have any number of tags, including 0.
+</div>
+
+<div markdown="span" class="alert alert-info">
+:information_source: **Note:** If contacted date is specified, it must be a valid [AD](https://en.wikipedia.org/wiki/Anno_Domini) date following the dd-mm-yyyy format, and must not be a future date. For both invalid date and incorrect format, the same error message will be shown to indicate that it needs to be a valid date that follows the proper format.
 </div>
 
 Examples:
@@ -212,6 +214,10 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
 * All the person’s tags or memo can be removed by typing `t/` or `m/` respectively without specifying text after it.
 * A peron's contacted date can be edited to "Not contacted" by typing `c/` without specifying a date after it.
+
+<div markdown="span" class="alert alert-info">
+:information_source: **Note:** If contacted date is specified, it must be a valid [AD](https://en.wikipedia.org/wiki/Anno_Domini) date following the dd-mm-yyyy format, and must not be a future date. For both invalid date and incorrect format, the same error message will be shown to indicate that it needs to be a valid date that follows the proper format.
+</div>
 
 Examples:
 * `edit 1 n/John Doe p/91234567 e/johndoe@example.com` edits the name, phone number and email address of the 1st person to be "John Doe", "91234567" and "johndoe@example.com" respectively.
@@ -254,9 +260,10 @@ Format: `deletetag INDEX t/TAG…`
 * If any of the tag to be deleted does not exist, the command will be rejected.
 * If `deletetag` is successful, the success display message will be based on the user's input. That is, if `deletetag 1 t/FRIENDS` is executed successfully and the tag "friends" (different capitalization) is deleted, "Deleted tag: [FRIENDS]" will be displayed.
 
-<div markdown="block" class="alert alert-info">
-:information_source: **Note:** To overwrite all existing tags or remove all tags in one go, refer to [4.1.2. Editing a person](#412-editing-a-person-edit).
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+ To overwrite all existing tags or remove all tags in one go, refer to [4.1.2. Editing a person](#412-editing-a-person-edit).
 </div>
+
 
 Examples:
 * `deletetag 1 t/friends` deletes the tag "friends" of the 1st person in the displayed list if the tag exists.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -181,7 +181,7 @@ Adds a person to the address book.
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED_DATE] [m/MEMO] [t/TAG]…​`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
- Contacted Date, Memo, and Tag are optional.
+ Contacted date, memo, and tag are optional.
 </div>
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
@@ -190,7 +190,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED_DATE] [m/MEMO]
 
 Examples:
 * `add n/Alice Eng p/98765432 e/aliceeng@example.com a/Alice street`
-* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 c/01-01-2020 m/Avid free climber`
+* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 c/01-01-2020 m/Avid hiker`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 m/Partner in crime t/criminal`
 
 [Back to Table of Contents](#table-of-contents-br)
@@ -207,13 +207,13 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CONTACTED DATE] 
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
-* You can remove all the person’s tags or memo by typing `t/` or `m/` respectively without specifying text after it.
-* You can edit a peron's contacted date to "Not contacted" by typing `c/` without specifying a date after it.
+* All the person’s tags or memo can be removed by typing `t/` or `m/` respectively without specifying text after it.
+* A peron's contacted date can be edited to "Not contacted" by typing `c/` without specifying a date after it.
 
 Examples:
-* `edit 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-* `edit 2 n/Betsy Crower t/` edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
-* `edit 2 m/Avid free climber` edits the memo of the 2nd person to be `Avid free climber`.
+* `edit 1 n/John Doe p/91234567 e/johndoe@example.com` edits the name, phone number and email address of the 1st person to be "John Doe", "91234567" and "johndoe@example.com" respectively.
+* `edit 2 t/` edits the 2nd person to clear all existing tags.
+* `edit 2 m/Avid hiker` edits the memo of the 2nd person to be `Avid hiker`.
 * `edit 2 c/01-01-2020` edits the contacted date of the 2nd person to be `Last contacted on 01-01-2020`.
 * `edit 2 m/ c/` edits the memo of the 2nd person to be empty and the contacted date to be `Not contacted`.
 
@@ -424,11 +424,16 @@ Examples:
 
 #### 4.7.1. Undoing commands: `undo`
 
-Undo previous commands that modified data, which includes: `add`, `edit`, `delete`, `clear`, `scrub`, `addtag` and `deletetag`.
+Undo previous commands that modified data, which includes: <br> 
+`add`, `edit`, `delete`, `clear`, `scrub`, `addtag` and `deletetag`.
 
 Format: `undo`
 
-- The maximum number of undo is 10.
+* The maximum number of undo is 10.
+
+<div markdown="span" class="alert alert-info">  
+:information_source: **Note:** If `undo` is successful, Abπ will display "Undo success!". Currently, it does not display a message on what has been undone. This message will be implemented in a future version.
+</div>
 
 Examples:
 * `undo` after calling `delete 1` restores the address book to its previous state prior to the deletion.
@@ -444,7 +449,11 @@ Redo reverses the `undo` command.
 
 Format: `redo`
 
-The maximum number of redo is 10.
+* The maximum number of redo is 10.
+
+<div markdown="span" class="alert alert-info">  
+:information_source: **Note:** If `redo` is successful, Abπ will display "Redo success!". Currently, it does not display a message on what has been redone. This message will be implemented in a future version.
+</div>
 
 Examples:
 * `redo` after calling `undo` restores the address book to its previous state prior to undo.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -180,6 +180,8 @@ Adds a person to the address book.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/CONTACTED_DATE] [m/MEMO] [t/TAG]…​`
 
+* If contacted date is specified, it must follow the dd-mm-yyyy format, cannot be in the future and must be a valid [AD](https://en.wikipedia.org/wiki/Anno_Domini) date. For both invalid date and incorrect format, the same error message will be shown to indicate that the date needs to be valid, following the proper format.
+
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
  Contacted date, memo, and tag are optional.
 </div>

--- a/src/main/java/seedu/address/model/StateAddressBook.java
+++ b/src/main/java/seedu/address/model/StateAddressBook.java
@@ -14,7 +14,7 @@ import seedu.address.model.exceptions.InvalidUndoException;
 public class StateAddressBook extends AddressBook {
 
     /** Limits the number of undo and redo. */
-    public static final int UNDO_REDO_CAPACITY = 20;
+    public static final int UNDO_REDO_CAPACITY = 10;
 
     /** Lists that contains the address book state history. */
     private final List<ReadOnlyAddressBook> stateHistory;

--- a/src/main/java/seedu/address/model/person/ContactedDate.java
+++ b/src/main/java/seedu/address/model/person/ContactedDate.java
@@ -31,8 +31,8 @@ public class ContactedDate {
             .withResolverStyle(ResolverStyle.STRICT);
 
     /** String message that represents message constraints. */
-    public static final String MESSAGE_CONSTRAINTS = "Last contacted date can either be empty or "
-            + "a VALID date following the dd-mm-yyyy format that is not in the future.";
+    public static final String MESSAGE_CONSTRAINTS = "Last contacted date can only either be empty or "
+            + "a VALID AD date following the dd-mm-yyyy format that is not in the future.";
 
     /** A static {@code contactedDate} object that represents an empty contacted date. */
     public static final ContactedDate EMPTY_CONTACTED_DATE = new ContactedDate("");


### PR DESCRIPTION
Fixes #219 

Clearly define what commands `Undo` undoes and limitations of the current `Undo` and `Redo` in `UserGuide.md`.