### PR TITLE
[#253] Add tests to AddTag command and AddTagCommandParser class

### DIFF
--- a/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
@@ -1,0 +1,244 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COLLEAGUE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_COMPANION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FAMILY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_WIFE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+
+class AddTagCommandTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_oneNonExistingTagSpecifiedUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson =
+                new PersonBuilder(firstPerson).withTags(VALID_TAG_COLLEAGUE, VALID_TAG_WIFE,
+                        VALID_TAG_FRIEND, VALID_TAG_COMPANION).build();
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_APPEND_TAG_SUCCESS, tagsToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_oneNonExistingTagDifferentCapitalizationSpecifiedUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_COLLEAGUE, VALID_TAG_WIFE,
+                VALID_TAG_FRIEND, VALID_TAG_COMPANION).build();
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION.toUpperCase()));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_APPEND_TAG_SUCCESS, tagsToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleNonExistingTagSpecifiedUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_COLLEAGUE, VALID_TAG_WIFE,
+                VALID_TAG_FRIEND, VALID_TAG_COMPANION, VALID_TAG_FAMILY).build();
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION));
+        tagsToAdd.add(new Tag(VALID_TAG_FAMILY));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_APPEND_TAG_SUCCESS, tagsToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noTagSpecifiedUnfilteredList_success() {
+        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_APPEND_TAG_SUCCESS, tagsToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_oneExistingTagSpecifiedUnfilteredList_failure() {
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_DUPLICATE_TAG, tagsToAdd);
+
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_twoExistingTagSpecifiedUnfilteredList_failure() {
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+        tagsToAdd.add(new Tag(VALID_TAG_COLLEAGUE));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_DUPLICATE_TAG, tagsToAdd);
+
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_oneExistingTagFollowedByOneNonExistingTagSpecifiedUnfilteredList_failure() {
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+        tagsToAdd.add(new Tag(VALID_TAG_FAMILY));
+
+        Set<Tag> existingTags = new HashSet<>();
+        existingTags.add(new Tag(VALID_TAG_FRIEND));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_DUPLICATE_TAG, existingTags);
+
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_oneNonExistingTagFollowedByOneExistingTagSpecifiedUnfilteredList_failure() {
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FAMILY));
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+
+        Set<Tag> existingTags = new HashSet<>();
+        existingTags.add(new Tag(VALID_TAG_FRIEND));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_DUPLICATE_TAG, existingTags);
+
+        assertCommandFailure(addTagCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_oneNonExistingTagSpecifiedFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_FRIEND, VALID_TAG_COLLEAGUE,
+                VALID_TAG_WIFE, VALID_TAG_COMPANION).build();
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION));
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+        String expectedMessage = String.format(AddTagCommand.MESSAGE_APPEND_TAG_SUCCESS, tagsToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.saveAddressBookState();
+
+        assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION));
+
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, tagsToAdd);
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION));
+
+        AddTagCommand addTagCommand = new AddTagCommand(outOfBoundIndex, tagsToAdd);
+
+        assertCommandFailure(addTagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_COMPANION));
+
+        final AddTagCommand standardCommand = new AddTagCommand(INDEX_FIRST_PERSON, tagsToAdd);
+
+        // same values -> returns true
+        Set<Tag> copyTagsToAdd = new HashSet<>(tagsToAdd);
+        AddTagCommand commandWithSameValues = new AddTagCommand(INDEX_FIRST_PERSON, copyTagsToAdd);
+        assertEquals(standardCommand, commandWithSameValues);
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+
+        // null -> returns false
+        assertNotEquals(null, standardCommand);
+
+        // different types -> returns false
+        assertNotEquals(standardCommand, new ClearCommand());
+
+        // different index -> returns false
+        assertNotEquals(standardCommand, new AddTagCommand(INDEX_SECOND_PERSON, tagsToAdd));
+
+        // different tags to add -> returns false
+        assertNotEquals(standardCommand, new AddTagCommand(INDEX_SECOND_PERSON, new HashSet<>()));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -50,6 +50,7 @@ public class CommandTestUtil {
     public static final String VALID_TAG_COLLEAGUE = "colleague";
     public static final String VALID_TAG_WIFE = "wife";
     public static final String VALID_TAG_COMPANION = "companion";
+    public static final String VALID_TAG_FAMILY = "family";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTagCommandParserTest.java
@@ -1,0 +1,111 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.model.tag.Tag;
+
+class AddTagCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(ParserUtil.MESSAGE_INVALID_INDEX, AddTagCommand.MESSAGE_USAGE);
+
+    private AddTagCommandParser parser = new AddTagCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", AddTagCommand.MESSAGE_MISSING_PREFIX);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // overflow max integer
+        assertParseFailure(parser, "2147483648" + VALID_TAG_FRIEND, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidTag_failure() {
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidTagFollowedByValidTag_failure() {
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC + TAG_DESC_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validTagFollowedByInvalidTag_failure() {
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_oneTagSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+
+        AddTagCommand expectedCommand = new AddTagCommand(targetIndex, tagsToAdd);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleTagsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+        tagsToAdd.add(new Tag(VALID_TAG_HUSBAND));
+
+        AddTagCommand expectedCommand = new AddTagCommand(targetIndex, tagsToAdd);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedTagsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND + TAG_DESC_FRIEND;
+
+        Set<Tag> tagsToAdd = new HashSet<>();
+        tagsToAdd.add(new Tag(VALID_TAG_FRIEND));
+
+        AddTagCommand expectedCommand = new AddTagCommand(targetIndex, tagsToAdd);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}


### PR DESCRIPTION
Fixes #253 .

Previously there was no unit testing done for both the `AddTagCommand` class and the `AddTagCommandParser` class.

Add new unit tests for both classes in `AddTagCommandTest` and `AddTagCommandParserTest`.