### PR TITLE
[#263] Revamp equality for phone numbers 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -528,7 +528,7 @@ Format: `exit`
 ### 4.9. Extra information regarding the features
 
 #### 4.9.1. Ignoring case difference
-Abπ ignores case difference for the person attributes `Name`, `Email`, `Address`, `Memo` and `Tag` to provide a more seamless experience that matches the real world.
+Abπ ignores case difference for the person attributes name, email, address, memo and tag to provide a more seamless experience that matches the real world.
 * Attributes that only differs in case sensitivity is considered as identical.
 
 Examples:
@@ -546,20 +546,19 @@ Examples:
 * "Likes &#160;&#160;&#160; to &#160;&#160;&#160; drink" will be trimmed to "Likes to drink".
 
 #### 4.9.3. Preventing duplicate entries
-Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands. 
+Abπ helps to manage duplicates by preventing duplicate entries of identical name, phone and email when using the `add` and `edit` commands.
 
 * Each contact in Abπ is uniquely identified by their name, phone and email, that is, a contact is only considered a duplicate if there already exists a contact in Abπ with the exact same name, phone and email.
 * The reason why duplicate is considered as such is to provide greater flexibility as different individuals may share the same name, or phone, or even email.
 
 <div markdown="span" class="alert alert-info">
 :information_source: **Note:** <br>
-For all person attributes, after extra white spaces have been trimmed, a difference in white space is considered as different. For example: <br>
-"John Doe" is different from "JohnDoe" <br>
-"65 98765432" is different from "6598765432" <br>
+For all person attributes except phone, after extra white spaces have been trimmed, a difference in white space is considered as different. For example: <br>
+"John Doe" is different from "JohnDoe" (difference in white space) <br>
 <br>
-For phone, a difference in "+" is also considered as different. For example: <br>
-"+65 98765432" is considered different from "65 98765432"
- 
+For phone, even if there is a difference in white space, it is still considered to be equal. However, a difference in '+' is considered as different. For example: <br>
+"+65 98765432" is equal to "+6598765432" (difference in white space) <br>
+"+65 98765432" is different from "65 98765432 (difference in '+')"
 </div>
 
 #### 4.9.4. Saving the data

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -48,7 +48,7 @@ public class Address {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Address // instanceof handles nulls
-                && address.equalsIgnoreCase(((Address) other).address)); // state check
+                && address.equalsIgnoreCase(((Address) other).address)); // case-insensitive
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/ContactedDate.java
+++ b/src/main/java/seedu/address/model/person/ContactedDate.java
@@ -120,7 +120,7 @@ public class ContactedDate {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ContactedDate // instanceof handles nulls
-                && contactedDate.equals(((ContactedDate) other).contactedDate)); // state check
+                && contactedDate.equals(((ContactedDate) other).contactedDate)); // case-insensitive
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -62,7 +62,7 @@ public class Email {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Email // instanceof handles nulls
-                && email.equalsIgnoreCase(((Email) other).email)); // state check
+                && email.equalsIgnoreCase(((Email) other).email)); // case-insensitive
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Memo.java
+++ b/src/main/java/seedu/address/model/person/Memo.java
@@ -13,7 +13,7 @@ public class Memo {
     public static final int MAXIMUM_CHARACTERS = 1000;
 
     /** String message that represents message constraints. */
-    public static final String MESSAGE_CONSTRAINTS = "Memo can take any values, up to a maximum of "
+    public static final String MESSAGE_CONSTRAINTS = "Memo can only be up to a maximum of "
             + MAXIMUM_CHARACTERS + " characters";
 
     /** Every character is allowed, up to a maximum of MAXIMUM_CHARACTERS. */
@@ -75,7 +75,7 @@ public class Memo {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Memo // instanceof handles nulls
-                && memo.equalsIgnoreCase(((Memo) other).memo)); // state check
+                && memo.equalsIgnoreCase(((Memo) other).memo)); // case-insensitive
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -51,7 +51,7 @@ public class Name {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equalsIgnoreCase(((Name) other).fullName)); // state check
+                && fullName.equalsIgnoreCase(((Name) other).fullName)); // case-insensitive
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -46,7 +46,8 @@ public class Phone {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Phone // instanceof handles nulls
-                && phone.equals(((Phone) other).phone)); // state check
+                && removeAllWhiteSpace(phone)
+                .equals(removeAllWhiteSpace(((Phone) other).phone))); // case-insensitive and ignores white space
     }
 
     /**
@@ -62,6 +63,17 @@ public class Phone {
 
     @Override
     public int hashCode() {
-        return phone.hashCode();
+        return removeAllWhiteSpace(phone).hashCode();
     }
+
+    /**
+     * Removes all white space from the given string.
+     *
+     * @param str String to remove all white space from.
+     * @return String with all white space removed.
+     */
+    private String removeAllWhiteSpace(String str) {
+        return str.replaceAll(" ", "");
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -16,7 +16,7 @@ public class Phone {
                     + "It should contain at least 3 numbers and cannot exceed " + PHONE_NUMBER_MAXIMUM
                     + " characters";
     public static final String VALIDATION_REGEX = "(?=^.{3,"
-            + PHONE_NUMBER_MAXIMUM + "}$)\\+?(\\d\\s*){3,}";
+            + PHONE_NUMBER_MAXIMUM + "}$)\\+?(\\d *){3,}";
     public final String phone;
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -37,7 +37,7 @@ public class Tag {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Tag // instanceof handles nulls
-                && tagName.equalsIgnoreCase(((Tag) other).tagName)); // state check
+                && tagName.equalsIgnoreCase(((Tag) other).tagName)); // case-insensitive
     }
 
     @Override

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -81,6 +81,13 @@ public class PhoneTest {
         Phone validPhoneAmyCopy = new Phone(VALID_PHONE_AMY);
         assertTrue(validPhoneAmy.equals(validPhoneAmyCopy));
 
+        // white space -> returns true
+        int halfLengthPhoneAmy = VALID_PHONE_AMY.length() / 2;
+        String phoneWithSpace = VALID_PHONE_AMY.substring(0, halfLengthPhoneAmy) + " "
+                + VALID_PHONE_AMY.substring(halfLengthPhoneAmy); // add white space to the center of the phone number
+        Phone validPhoneWithSpace = new Phone(phoneWithSpace);
+        assertTrue(validPhoneAmy.equals(validPhoneWithSpace));
+
         // different types -> returns false
         assertFalse(validPhoneAmy.equals(1));
 

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -66,6 +66,13 @@ public class PhoneTest {
         // different phone -> returns false
         Phone validPhoneBob = new Phone(VALID_PHONE_BOB);
         assertFalse(validPhoneAmy.exactEquals(validPhoneBob));
+
+        // white space -> returns false
+        int halfLengthPhoneAmy = VALID_PHONE_AMY.length() / 2;
+        String phoneWithSpace = VALID_PHONE_AMY.substring(0, halfLengthPhoneAmy) + " "
+                + VALID_PHONE_AMY.substring(halfLengthPhoneAmy); // add white space to the center of the phone number
+        Phone validPhoneWithSpace = new Phone(phoneWithSpace);
+        assertFalse(validPhoneAmy.exactEquals(validPhoneWithSpace));
     }
 
     @Test


### PR DESCRIPTION
Fixes #263

Previous `Phone#equals(Object)` considered "+65 98765432" and "+6598765432" to be different.

Update `Phone#equals(Object)` to ignore white spaces, such that "+65 98765432" and "+6598765432" is considered equal. This is better reflect reality, in that phone numbers are identical even if one have white spaces between them.