### PR TITLE
[#269] Remove duplicated code Phone#removeAllWhiteSpace(String)

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -94,13 +94,13 @@ public class StringUtil {
     }
 
     /**
-     * Removes all the white space in the input string.
+     * Removes all the white space from the given string.
      *
-     * @param userInput User input that is targeted for white space removal.
+     * @param str String for white space removal.
      * @return A string that has its whitespaces completely removed.
      */
-    public static String removeSpaces(String userInput) {
-        return userInput.replace(" ", "");
+    public static String removeSpaces(String str) {
+        return str.replace(" ", "");
     }
 
     /**
@@ -113,5 +113,15 @@ public class StringUtil {
         List<String> resultList = new ArrayList<>();
         userList.forEach(inputStr -> resultList.add(inputStr.replace(" ", "")));
         return resultList;
+    }
+
+    /**
+     * Replaces 2 or more consecutive whitespaces between words with a single whitespace.
+     *
+     * @param str String to be trimmed.
+     * @return Trimmed string with extra whitespaces removed.
+     */
+    public static String trimExtraWhiteSpaces(String str) {
+        return str.replaceAll("\\s{2,}", " ");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.util.StringUtil.trimExtraWhiteSpaces;
 import static seedu.address.logic.commands.FindCommand.NO_PREFIX_MESSAGE;
 import static seedu.address.logic.parser.CliSyntax.ARRAY_OF_PREFIX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACTED_DATE;
@@ -46,7 +47,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         // Removes trailing whitespace from the user input
         String trimmedArgs = args.stripTrailing();
         // Regex to replace 2 or more consecutive whitespaces with a single whitespace between words
-        String modifiedString = ParserUtil.trimExtraWhiteSpaces(trimmedArgs);
+        String modifiedString = trimExtraWhiteSpaces(trimmedArgs);
         if (modifiedString.isEmpty()) {
             LOGGER.log(Level.INFO, "Input is empty");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.StringUtil.trimExtraWhiteSpaces;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -163,16 +164,6 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
-    }
-
-    /**
-     * Replaces 2 or more consecutive whitespaces between words with a single whitespace.
-     *
-     * @param str String to be trimmed.
-     * @return Trimmed string with extra whitespaces removed.
-     */
-    public static String trimExtraWhiteSpaces(String str) {
-        return str.replaceAll("\\s{2,}", " ");
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.StringUtil.removeSpaces;
 
 /**
  * Represents a Person's phone number in the address book.
@@ -46,8 +47,8 @@ public class Phone {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Phone // instanceof handles nulls
-                && removeAllWhiteSpace(phone)
-                .equals(removeAllWhiteSpace(((Phone) other).phone))); // case-insensitive and ignores white space
+                && removeSpaces(phone)
+                .equals(removeSpaces(((Phone) other).phone))); // case-insensitive and ignores white space
     }
 
     /**
@@ -63,17 +64,7 @@ public class Phone {
 
     @Override
     public int hashCode() {
-        return removeAllWhiteSpace(phone).hashCode();
-    }
-
-    /**
-     * Removes all white space from the given string.
-     *
-     * @param str String to remove all white space from.
-     * @return String with all white space removed.
-     */
-    private String removeAllWhiteSpace(String str) {
-        return str.replaceAll(" ", "");
+        return removeSpaces(phone).hashCode();
     }
 
 }


### PR DESCRIPTION
Fixes #269 

Previous `Phone#removeAllWhiteSpace(String)` removes all spaces, but a identical function was implemented in `StringUtil` as well.

Remove duplicated code `Phone#removeAllWhiteSpace(String)` and replace it with `StringUtil#removeSpaces(String)`.